### PR TITLE
basic matrix runner

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,7 @@ xlang:
 	docker-compose run xlang
 
 
-.PHONY: publish
-publish:
-	./scripts/publish-to-docker-registry.sh
+.PHONY: run
+run:
+	docker-compose build xlang
+	docker-compose run xlang

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,26 +5,35 @@ xlang:
         - yarpc-java
         - yarpc-python
         - yarpc-node
+    environment:
+        - XLANG_CLIENTS=yarpc-go,yarpc-java,yarpc-python,yarpc-node
+        - XLANG_SERVERS=yarpc-go,yarpc-java,yarpc-python,yarpc-node
+        - XLANG_BEHAVIORS=call,not_found
 
 yarpc-go:
-    image: yarpc/yarpc-go
+    # image: yarpc/yarpc-go
+    image: tutum/hello-world
     ports:
-        - 80:8080  # TODO should listen on 80 internally
+        - 80
+        - 81
 
 yarpc-java:
     # image: yarpc/yarpc-java
     image: tutum/hello-world
     ports:
         - 80
+        - 81
 
 yarpc-python:
     # image: yarpc/yarpc-python
     image: tutum/hello-world
     ports:
         - 80
+        - 81
 
 yarpc-node:
     # image: yarpc/yarpc-node
     image: tutum/hello-world
     ports:
         - 80
+        - 81


### PR DESCRIPTION
Initial runner issues a structured http request to each `XLANG_CLIENT` over port `80` and the specified `server` and `behavior` for the client to call. At the moment I blow up if anything fails, but will improve on it to continue and report the failure in a more obvious way.

Given the xlang config:

```
xlang:
    build: .
    links:
        - yarpc-go
        - yarpc-java
        - yarpc-python
        - yarpc-node
    environment:
        - XLANG_CLIENTS=yarpc-go,yarpc-java,yarpc-python,yarpc-node
        - XLANG_SERVERS=yarpc-go,yarpc-java,yarpc-python,yarpc-node
        - XLANG_BEHAVIORS=call,not_found
```

Here is what the output looks like when ran:

```
yarpc/xlang - [runner] » make xlang
docker-compose run xlang
+ exec app
2016/01/28 02:58:43 200 http://yarpc-go?behavior=call&server=yarpc-go
2016/01/28 02:58:43 200 http://yarpc-go?behavior=not_found&server=yarpc-go
2016/01/28 02:58:43 200 http://yarpc-go?behavior=call&server=yarpc-java
2016/01/28 02:58:43 200 http://yarpc-go?behavior=not_found&server=yarpc-java
2016/01/28 02:58:43 200 http://yarpc-go?behavior=call&server=yarpc-python
2016/01/28 02:58:43 200 http://yarpc-go?behavior=not_found&server=yarpc-python
2016/01/28 02:58:43 200 http://yarpc-go?behavior=call&server=yarpc-node
2016/01/28 02:58:43 200 http://yarpc-go?behavior=not_found&server=yarpc-node
2016/01/28 02:58:43 200 http://yarpc-java?behavior=call&server=yarpc-go
2016/01/28 02:58:43 200 http://yarpc-java?behavior=not_found&server=yarpc-go
2016/01/28 02:58:43 200 http://yarpc-java?behavior=call&server=yarpc-java
2016/01/28 02:58:43 200 http://yarpc-java?behavior=not_found&server=yarpc-java
2016/01/28 02:58:43 200 http://yarpc-java?behavior=call&server=yarpc-python
2016/01/28 02:58:43 200 http://yarpc-java?behavior=not_found&server=yarpc-python
2016/01/28 02:58:43 200 http://yarpc-java?behavior=call&server=yarpc-node
2016/01/28 02:58:43 200 http://yarpc-java?behavior=not_found&server=yarpc-node
2016/01/28 02:58:43 200 http://yarpc-python?behavior=call&server=yarpc-go
2016/01/28 02:58:43 200 http://yarpc-python?behavior=not_found&server=yarpc-go
2016/01/28 02:58:43 200 http://yarpc-python?behavior=call&server=yarpc-java
2016/01/28 02:58:43 200 http://yarpc-python?behavior=not_found&server=yarpc-java
2016/01/28 02:58:43 200 http://yarpc-python?behavior=call&server=yarpc-python
2016/01/28 02:58:43 200 http://yarpc-python?behavior=not_found&server=yarpc-python
2016/01/28 02:58:43 200 http://yarpc-python?behavior=call&server=yarpc-node
2016/01/28 02:58:43 200 http://yarpc-python?behavior=not_found&server=yarpc-node
2016/01/28 02:58:43 200 http://yarpc-node?behavior=call&server=yarpc-go
2016/01/28 02:58:43 200 http://yarpc-node?behavior=not_found&server=yarpc-go
2016/01/28 02:58:43 200 http://yarpc-node?behavior=call&server=yarpc-java
2016/01/28 02:58:43 200 http://yarpc-node?behavior=not_found&server=yarpc-java
2016/01/28 02:58:43 200 http://yarpc-node?behavior=call&server=yarpc-python
2016/01/28 02:58:43 200 http://yarpc-node?behavior=not_found&server=yarpc-python
2016/01/28 02:58:43 200 http://yarpc-node?behavior=call&server=yarpc-node
2016/01/28 02:58:43 200 http://yarpc-node?behavior=not_found&server=yarpc-node
```

This first step allows the other language repos to start take advantage of this structure.

cc @yarpc/yarpc 
