### PR TITLE
Configurable Matrix Dimensions

### DIFF
--- a/case.go
+++ b/case.go
@@ -1,0 +1,47 @@
+package main
+
+// Arguments represents custom args to pass to test client.
+type Arguments map[string]string
+
+// TestCase represents the request made to test clients.
+type TestCase struct {
+	Client    string
+	Arguments Arguments
+}
+
+// Collect all TestCases for a given Matrix
+func Collect(matrix Matrix) []TestCase {
+	var cases []TestCase
+	for _, client := range matrix.Clients {
+		clientTestCases := createCasesForClient(client, matrix.Dimensions, make(map[string]string))
+		cases = append(cases, clientTestCases...)
+	}
+
+	return cases
+}
+
+func createCasesForClient(client string, dimensions []Dimension, args Arguments) []TestCase {
+	if len(dimensions) == 0 {
+		return []TestCase{{
+			Client:    client,
+			Arguments: copyArgs(args),
+		}}
+	}
+
+	var testCases []TestCase
+
+	d := dimensions[0]
+	for _, p := range d.Values {
+		args[d.Name] = p
+		testCases = append(testCases, createCasesForClient(client, dimensions[1:], args)...)
+	}
+	return testCases
+}
+
+func copyArgs(args Arguments) Arguments {
+	copy := make(map[string]string)
+	for k, v := range args {
+		copy[k] = v
+	}
+	return copy
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,9 @@ xlang:
         - yarpc-node
     environment:
         - XLANG_CLIENTS=yarpc-go,yarpc-java,yarpc-python,yarpc-node
-        - XLANG_SERVERS=yarpc-go,yarpc-java,yarpc-python,yarpc-node
-        - XLANG_BEHAVIORS=call,not_found
+        - XLANG_DIMENSION_SERVER=yarpc-go,yarpc-java,yarpc-python,yarpc-node
+        - XLANG_DIMENSION_BEHAVIOR=call,not_found
+        - XLANG_DIMENSION_TRANSPORT=tchannel,http
 
 yarpc-go:
     image: breerly/hello-server

--- a/environ.go
+++ b/environ.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"os"
+	"strings"
+)
+
+const clientsKey = "XLANG_CLIENTS"
+const dimensionKeyPrefix = "XLANG_DIMENSION_"
+
+// ReadMatrixFromEnviron creates a Matrix by looking for XLANG_ environment vars
+func ReadMatrixFromEnviron() Matrix {
+	clients := strings.Split(os.Getenv(clientsKey), ",")
+	var dimensions []Dimension
+
+	for _, e := range os.Environ() {
+		if !strings.HasPrefix(e, dimensionKeyPrefix) {
+			continue
+		}
+		d := strings.TrimPrefix(e, dimensionKeyPrefix)
+
+		pair := strings.SplitN(d, "=", 2)
+		key := strings.ToLower(pair[0])
+		value := strings.Split(pair[1], ",")
+
+		dimension := Dimension{
+			Name:   key,
+			Values: value,
+		}
+		dimensions = append(dimensions, dimension)
+	}
+
+	matrix := Matrix{
+		Clients:    clients,
+		Dimensions: dimensions,
+	}
+
+	return matrix
+}

--- a/main.go
+++ b/main.go
@@ -2,28 +2,17 @@ package main
 
 import (
 	"fmt"
-	"os"
-	"strings"
 	"time"
 )
 
 func main() {
-
-	clients := strings.Split(os.Getenv("XLANG_CLIENTS"), ",")
-	servers := strings.Split(os.Getenv("XLANG_SERVERS"), ",")
-	behaviors := strings.Split(os.Getenv("XLANG_BEHAVIORS"), ",")
-
-	matrix := Matrix{
-		Clients:   clients,
-		Servers:   servers,
-		Behaviors: behaviors,
-	}
+	matrix := ReadMatrixFromEnviron()
 
 	fmt.Println("Waiting 1 second for test clients to come online")
 	time.Sleep(1 * time.Second)
 
 	fmt.Println("Begining matrix of tests")
-	results := BeginMatrixTest(matrix)
+	results := Execute(matrix)
 
-	OutputResults(results)
+	Output(results)
 }

--- a/output.go
+++ b/output.go
@@ -2,20 +2,27 @@ package main
 
 import (
 	"fmt"
+	"log"
 	"os"
 
 	"github.com/olekukonko/tablewriter"
 )
 
-func OutputResults(results Results) {
+// Output results to the console
+func Output(results []Result) {
+	if len(results) == 0 {
+		log.Fatal("no results...")
+	}
+
+	var headers []string
+	for key := range results[0].TestCase.Arguments {
+		headers = append(headers, key)
+	}
 
 	table := tablewriter.NewWriter(os.Stdout)
-	table.SetHeader([]string{"Status", "Client", "Server", "Behavior", "Response"})
-	table.SetBorder(false)
 
 	for _, result := range results {
-
-		row := make([]string, 0)
+		var row []string
 
 		switch result.Status {
 		case Success:
@@ -27,12 +34,18 @@ func OutputResults(results Results) {
 		}
 
 		row = append(row, result.TestCase.Client)
-		row = append(row, result.TestCase.Server)
-		row = append(row, result.TestCase.Behavior)
 		row = append(row, result.Response)
+
+		for _, header := range headers {
+			row = append(row, result.TestCase.Arguments[header])
+		}
 
 		table.Append(row)
 	}
+
+	headers = append([]string{"status", "client", "response"}, headers...)
+	table.SetHeader(headers)
+	table.SetBorder(false)
 
 	fmt.Println()
 	table.Render() // Send output


### PR DESCRIPTION
This is ready to go.
## 0 dimension

```
xlang:
    build: .
    links:
        - yarpc-go
        - yarpc-java
        - yarpc-python
        - yarpc-node
    environment:
        - XLANG_CLIENTS=yarpc-go,yarpc-java,yarpc-python,yarpc-node
```

```
$ make xlang

Begining matrix of tests

  STATUS |    CLIENT    |   RESPONSE
+--------+--------------+--------------+
  PASSED | yarpc-go     | Hello World!
  PASSED | yarpc-java   | Hello World!
  PASSED | yarpc-python | Hello World!
  PASSED | yarpc-node   | Hello World!
```
## 1 dimension

```
xlang:
    build: .
    links:
        - yarpc-go
        - yarpc-java
        - yarpc-python
        - yarpc-node
    environment:
        - XLANG_CLIENTS=yarpc-go,yarpc-java,yarpc-python,yarpc-node
        - XLANG_DIMENSION_SERVER=yarpc-go,yarpc-java,yarpc-python,yarpc-node
```

```
$ make xlang

Begining matrix of tests

  STATUS |    CLIENT    |   RESPONSE   |    SERVER
+--------+--------------+--------------+--------------+
  PASSED | yarpc-go     | Hello World! | yarpc-go
  PASSED | yarpc-go     | Hello World! | yarpc-java
  PASSED | yarpc-go     | Hello World! | yarpc-python
  PASSED | yarpc-go     | Hello World! | yarpc-node
  PASSED | yarpc-java   | Hello World! | yarpc-go
  PASSED | yarpc-java   | Hello World! | yarpc-java
  PASSED | yarpc-java   | Hello World! | yarpc-python
  PASSED | yarpc-java   | Hello World! | yarpc-node
  PASSED | yarpc-python | Hello World! | yarpc-go
  PASSED | yarpc-python | Hello World! | yarpc-java
  PASSED | yarpc-python | Hello World! | yarpc-python
  PASSED | yarpc-python | Hello World! | yarpc-node
  PASSED | yarpc-node   | Hello World! | yarpc-go
  PASSED | yarpc-node   | Hello World! | yarpc-java
  PASSED | yarpc-node   | Hello World! | yarpc-python
  PASSED | yarpc-node   | Hello World! | yarpc-node
```
## 2 dimensions

```
xlang:
    build: .
    links:
        - yarpc-go
        - yarpc-java
        - yarpc-python
        - yarpc-node
    environment:
        - XLANG_CLIENTS=yarpc-go,yarpc-java,yarpc-python,yarpc-node
        - XLANG_DIMENSION_SERVER=yarpc-go,yarpc-java,yarpc-python,yarpc-node
        - XLANG_DIMENSION_BEHAVIOR=call,not_found
```

```
$ make xlang

Begining matrix of tests

  STATUS |    CLIENT    |   RESPONSE   |    SERVER    | BEHAVIOR
+--------+--------------+--------------+--------------+-----------+
  PASSED | yarpc-go     | Hello World! | yarpc-go     | call
  PASSED | yarpc-go     | Hello World! | yarpc-go     | not_found
  PASSED | yarpc-go     | Hello World! | yarpc-java   | call
  PASSED | yarpc-go     | Hello World! | yarpc-java   | not_found
  PASSED | yarpc-go     | Hello World! | yarpc-python | call
  PASSED | yarpc-go     | Hello World! | yarpc-python | not_found
  PASSED | yarpc-go     | Hello World! | yarpc-node   | call
  PASSED | yarpc-go     | Hello World! | yarpc-node   | not_found
  PASSED | yarpc-java   | Hello World! | yarpc-go     | call
  PASSED | yarpc-java   | Hello World! | yarpc-go     | not_found
  PASSED | yarpc-java   | Hello World! | yarpc-java   | call
  PASSED | yarpc-java   | Hello World! | yarpc-java   | not_found
  PASSED | yarpc-java   | Hello World! | yarpc-python | call
  PASSED | yarpc-java   | Hello World! | yarpc-python | not_found
  PASSED | yarpc-java   | Hello World! | yarpc-node   | call
  PASSED | yarpc-java   | Hello World! | yarpc-node   | not_found
  PASSED | yarpc-python | Hello World! | yarpc-go     | call
  PASSED | yarpc-python | Hello World! | yarpc-go     | not_found
  PASSED | yarpc-python | Hello World! | yarpc-java   | call
  PASSED | yarpc-python | Hello World! | yarpc-java   | not_found
  PASSED | yarpc-python | Hello World! | yarpc-python | call
  PASSED | yarpc-python | Hello World! | yarpc-python | not_found
  PASSED | yarpc-python | Hello World! | yarpc-node   | call
  PASSED | yarpc-python | Hello World! | yarpc-node   | not_found
  PASSED | yarpc-node   | Hello World! | yarpc-go     | call
  PASSED | yarpc-node   | Hello World! | yarpc-go     | not_found
  PASSED | yarpc-node   | Hello World! | yarpc-java   | call
  PASSED | yarpc-node   | Hello World! | yarpc-java   | not_found
  PASSED | yarpc-node   | Hello World! | yarpc-python | call
  PASSED | yarpc-node   | Hello World! | yarpc-python | not_found
  PASSED | yarpc-node   | Hello World! | yarpc-node   | call
  PASSED | yarpc-node   | Hello World! | yarpc-node   | not_found
```
## 3 dimensions

```
xlang:
    build: .
    links:
        - yarpc-go
        - yarpc-java
        - yarpc-python
        - yarpc-node
    environment:
        - XLANG_CLIENTS=yarpc-go,yarpc-java,yarpc-python,yarpc-node
        - XLANG_DIMENSION_SERVER=yarpc-go,yarpc-java,yarpc-python,yarpc-node
        - XLANG_DIMENSION_BEHAVIOR=call,not_found
        - XLANG_DIMENSION_TRANSPORT=tchannel,http
```

```
$ make xlang

Begining matrix of tests

  STATUS |    CLIENT    |   RESPONSE   |    SERVER    | BEHAVIOR  | TRANSPORT
+--------+--------------+--------------+--------------+-----------+-----------+
  PASSED | yarpc-go     | Hello World! | yarpc-go     | call      | tchannel
  PASSED | yarpc-go     | Hello World! | yarpc-go     | call      | http
  PASSED | yarpc-go     | Hello World! | yarpc-go     | not_found | tchannel
  PASSED | yarpc-go     | Hello World! | yarpc-go     | not_found | http
  PASSED | yarpc-go     | Hello World! | yarpc-java   | call      | tchannel
  PASSED | yarpc-go     | Hello World! | yarpc-java   | call      | http
  PASSED | yarpc-go     | Hello World! | yarpc-java   | not_found | tchannel
  PASSED | yarpc-go     | Hello World! | yarpc-java   | not_found | http
  PASSED | yarpc-go     | Hello World! | yarpc-python | call      | tchannel
  PASSED | yarpc-go     | Hello World! | yarpc-python | call      | http
  PASSED | yarpc-go     | Hello World! | yarpc-python | not_found | tchannel
  PASSED | yarpc-go     | Hello World! | yarpc-python | not_found | http
  PASSED | yarpc-go     | Hello World! | yarpc-node   | call      | tchannel
  PASSED | yarpc-go     | Hello World! | yarpc-node   | call      | http
  PASSED | yarpc-go     | Hello World! | yarpc-node   | not_found | tchannel
  PASSED | yarpc-go     | Hello World! | yarpc-node   | not_found | http
  PASSED | yarpc-java   | Hello World! | yarpc-go     | call      | tchannel
  PASSED | yarpc-java   | Hello World! | yarpc-go     | call      | http
  PASSED | yarpc-java   | Hello World! | yarpc-go     | not_found | tchannel
  PASSED | yarpc-java   | Hello World! | yarpc-go     | not_found | http
  PASSED | yarpc-java   | Hello World! | yarpc-java   | call      | tchannel
  PASSED | yarpc-java   | Hello World! | yarpc-java   | call      | http
  PASSED | yarpc-java   | Hello World! | yarpc-java   | not_found | tchannel
  PASSED | yarpc-java   | Hello World! | yarpc-java   | not_found | http
  PASSED | yarpc-java   | Hello World! | yarpc-python | call      | tchannel
  PASSED | yarpc-java   | Hello World! | yarpc-python | call      | http
  PASSED | yarpc-java   | Hello World! | yarpc-python | not_found | tchannel
  PASSED | yarpc-java   | Hello World! | yarpc-python | not_found | http
  PASSED | yarpc-java   | Hello World! | yarpc-node   | call      | tchannel
  PASSED | yarpc-java   | Hello World! | yarpc-node   | call      | http
  PASSED | yarpc-java   | Hello World! | yarpc-node   | not_found | tchannel
  PASSED | yarpc-java   | Hello World! | yarpc-node   | not_found | http
  PASSED | yarpc-python | Hello World! | yarpc-go     | call      | tchannel
  PASSED | yarpc-python | Hello World! | yarpc-go     | call      | http
  PASSED | yarpc-python | Hello World! | yarpc-go     | not_found | tchannel
  PASSED | yarpc-python | Hello World! | yarpc-go     | not_found | http
  PASSED | yarpc-python | Hello World! | yarpc-java   | call      | tchannel
  PASSED | yarpc-python | Hello World! | yarpc-java   | call      | http
  PASSED | yarpc-python | Hello World! | yarpc-java   | not_found | tchannel
  PASSED | yarpc-python | Hello World! | yarpc-java   | not_found | http
  PASSED | yarpc-python | Hello World! | yarpc-python | call      | tchannel
  PASSED | yarpc-python | Hello World! | yarpc-python | call      | http
  PASSED | yarpc-python | Hello World! | yarpc-python | not_found | tchannel
  PASSED | yarpc-python | Hello World! | yarpc-python | not_found | http
  PASSED | yarpc-python | Hello World! | yarpc-node   | call      | tchannel
  PASSED | yarpc-python | Hello World! | yarpc-node   | call      | http
  PASSED | yarpc-python | Hello World! | yarpc-node   | not_found | tchannel
  PASSED | yarpc-python | Hello World! | yarpc-node   | not_found | http
  PASSED | yarpc-node   | Hello World! | yarpc-go     | call      | tchannel
  PASSED | yarpc-node   | Hello World! | yarpc-go     | call      | http
  PASSED | yarpc-node   | Hello World! | yarpc-go     | not_found | tchannel
  PASSED | yarpc-node   | Hello World! | yarpc-go     | not_found | http
  PASSED | yarpc-node   | Hello World! | yarpc-java   | call      | tchannel
  PASSED | yarpc-node   | Hello World! | yarpc-java   | call      | http
  PASSED | yarpc-node   | Hello World! | yarpc-java   | not_found | tchannel
  PASSED | yarpc-node   | Hello World! | yarpc-java   | not_found | http
  PASSED | yarpc-node   | Hello World! | yarpc-python | call      | tchannel
  PASSED | yarpc-node   | Hello World! | yarpc-python | call      | http
  PASSED | yarpc-node   | Hello World! | yarpc-python | not_found | tchannel
  PASSED | yarpc-node   | Hello World! | yarpc-python | not_found | http
  PASSED | yarpc-node   | Hello World! | yarpc-node   | call      | tchannel
  PASSED | yarpc-node   | Hello World! | yarpc-node   | call      | http
  PASSED | yarpc-node   | Hello World! | yarpc-node   | not_found | tchannel
  PASSED | yarpc-node   | Hello World! | yarpc-node   | not_found | http
```
