### PR TITLE
fix scratch image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ run:
 
 .PHONY: scratch
 scratch:
-	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main `glide novendor`
+	CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
 	docker build -f Dockerfile.scratch -t scratch-crossdock .
 	docker run scratch-crossdock
 


### PR DESCRIPTION
adding the examples dir resulted in the scratch image failing:

```
$ CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main `glide novendor`
go build: cannot use -o with multiple packages
```

cc @kriskowal 
