### PR TITLE
Fix travis overwriting Docker hub container

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,10 @@ script:
   - make crossdock
 
 after_success:
-  - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
   - export REPO=yarpc/crossdock
   - export BRANCH=`git name-rev --name-only HEAD`
   - export TAG=`if [ "$BRANCH" == "master" ]; then echo "latest"; else echo $BRANCH; fi`
+  - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
   - CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
   - docker build -f Dockerfile.scratch -t $REPO:$COMMIT .
   - docker run $REPO:$COMMIT

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,10 @@ script:
 
 after_success:
   - export REPO=yarpc/crossdock
-  - export BRANCH=`git name-rev --name-only HEAD`
+  - export PR=https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST
+  - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo `curl -s $PR | jq -r .head.ref`; fi)
   - export TAG=`if [ "$BRANCH" == "master" ]; then echo "latest"; else echo $BRANCH; fi`
+  - echo "REPO=$REPO, PR=$PR, BRANCH=$BRANCH, TAG=$TAG"
   - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
   - CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
   - docker build -f Dockerfile.scratch -t $REPO:$COMMIT .

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ script:
 after_success:
   - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
   - export REPO=yarpc/crossdock
-  - export TAG=`if [ "$TRAVIS_BRANCH" == "master" ]; then echo "latest"; else echo $TRAVIS_BRANCH; fi`
+  - export BRANCH=`git name-rev --name-only HEAD`
+  - export TAG=`if [ "$BRANCH" == "master" ]; then echo "latest"; else echo $BRANCH; fi`
   - CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
   - docker build -f Dockerfile.scratch -t $REPO:$COMMIT .
   - docker run $REPO:$COMMIT

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ after_success:
   - export PR=https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/$TRAVIS_PULL_REQUEST
   - export BRANCH=$(if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then echo $TRAVIS_BRANCH; else echo `curl -s $PR | jq -r .head.ref`; fi)
   - export TAG=`if [ "$BRANCH" == "master" ]; then echo "latest"; else echo $BRANCH; fi`
-  - echo "REPO=$REPO, PR=$PR, BRANCH=$BRANCH, TAG=$TAG"
+  - echo "TRAVIS_BRANCH=$TRAVIS_BRANCH, REPO=$REPO, PR=$PR, BRANCH=$BRANCH, TAG=$TAG"
   - docker login -e $DOCKER_EMAIL -u $DOCKER_USER -p $DOCKER_PASS
   - CGO_ENABLED=0 GOOS=linux go build -a -installsuffix cgo -o main .
   - docker build -f Dockerfile.scratch -t $REPO:$COMMIT .


### PR DESCRIPTION
Fixes #31 

travis-ci/pr now creates the same `TAG`:

```
TRAVIS_BRANCH=master
REPO=yarpc/crossdock
PR=https://api.github.com/repos/yarpc/crossdock/pulls/32
BRANCH=fix-hub-overwrite
TAG=fix-hub-overwrite
```

as travis-ci/push:

```
TRAVIS_BRANCH=fix-hub-overwrite
REPO=yarpc/crossdock
PR=https://api.github.com/repos/yarpc/crossdock/pulls/false
BRANCH=fix-hub-overwrite
TAG=fix-hub-overwrite
```

This can be verified on [Docker Hub](https://hub.docker.com/r/yarpc/crossdock/tags/):

```
fix-hub-overwrite - 2 MB - 7 minutes ago
latest - 2 MB - 19 hours ago
```

cc @yarpc/yarpc 
