### PR TITLE
ui improvement - use colors and ascii checks for output

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,7 +11,7 @@ crossdock:
       - CROSSDOCK_AXIS_TRANSPORT=http,tchannel
 
       - CROSSDOCK_BEHAVIOR_DANCE=client,server,transport
-      - CROSSDOCK_BEHAVIOR_SLING=client,server,transport
+      - CROSSDOCK_BEHAVIOR_SING=client,server,transport
 
 alpha:
     image: breerly/hello-server

--- a/glide.lock
+++ b/glide.lock
@@ -1,28 +1,16 @@
-hash: a9ed92449114cbbd11060d51558da53106f9168adb7aa560f0d599259205db0f
-updated: 2016-03-29T14:50:13.894112344-07:00
+hash: e71d26850e3330d56ee3e2d9938eace145c780305e761b47abc640608d2214ff
+updated: 2016-04-12T12:35:09.86721773-07:00
 imports:
-- name: github.com/davecgh/go-spew
-  version: 2df174808ee097f90d259e432cc04442cf60be21
-  subpackages:
-  - spew
-- name: github.com/mattn/go-runewidth
-  version: e882a96ec18dd43fa283187b66af74497c9101c0
+- name: github.com/fatih/color
+  version: 533cd7fd8a85905f67a1753afb4deddc85ea174f
 - name: github.com/olekukonko/tablewriter
   version: cca8bbc0798408af109aaaa239cbd2634846b340
 - name: github.com/orchestrate-io/dvr
   version: adafdc8de746d2a490c15a8ab8704c6110a0dcd6
-- name: github.com/pmezard/go-difflib
-  version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
-  subpackages:
-  - difflib
-- name: github.com/stretchr/objx
-  version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
   version: 9f9027faeb0dad515336ed2f28317f9f8f527ab4
   subpackages:
   - assert
-  - http
-  - mock
 - name: golang.org/x/net
   version: 35b06af0720201bc2f326773a80767387544f8c4
   subpackages:

--- a/glide.yaml
+++ b/glide.yaml
@@ -8,3 +8,4 @@ import:
 - package: golang.org/x/net
   subpackages:
   - context
+- package: github.com/fatih/color

--- a/output/stream.go
+++ b/output/stream.go
@@ -25,7 +25,13 @@ import (
 	"fmt"
 
 	"github.com/yarpc/crossdock/execute"
+
+	"github.com/fatih/color"
 )
+
+var green = color.New(color.FgGreen).SprintFunc()
+var yellow = color.New(color.FgYellow).SprintFunc()
+var red = color.New(color.FgRed).SprintFunc()
 
 // Stream results to the console, error at end if any fail
 func Stream(tests <-chan execute.TestResponse) error {
@@ -35,11 +41,11 @@ func Stream(tests <-chan execute.TestResponse) error {
 			var statStr string
 			switch result.Status {
 			case execute.Success:
-				statStr = "PASSED"
+				statStr = green("✓")
 			case execute.Skipped:
-				statStr = "SKIPPED"
+				statStr = yellow("S")
 			default:
-				statStr = "FAILED"
+				statStr = red("F")
 				failed = true
 			}
 			fmt.Printf("%v - %v - %v\n", statStr, test.TestCase, result.Output)


### PR DESCRIPTION
Currently if you get failures it's really really difficult to see which ones failed; this improves that.

<img width="414" alt="screen shot 2016-04-12 at 1 18 29 pm" src="https://cloud.githubusercontent.com/assets/263587/14474319/419fd028-00b1-11e6-9e20-3594fac585e1.png">

@yarpc/yarpc
