### PR TITLE
Add counts to test output

### DIFF
--- a/main.go
+++ b/main.go
@@ -46,10 +46,10 @@ func main() {
 	fmt.Printf("\nExecuting Matrix...\n\n")
 	results := execute.Run(plan)
 
-	summary, err := output.Stream(results)
+	summary := output.Stream(results)
 	output.Summarize(summary)
 
-	if err != nil {
+	if summary.Failed == true {
 		os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -46,9 +46,10 @@ func main() {
 	fmt.Printf("\nExecuting Matrix...\n\n")
 	results := execute.Run(plan)
 
-	if err := output.Stream(results); err != nil {
-		fmt.Printf("\nTests did not pass!\n\n")
+	summary, err := output.Stream(results)
+	output.Summarize(summary)
+
+	if err != nil {
 		os.Exit(1)
 	}
-	fmt.Printf("\nTests passed!\n\n")
 }

--- a/output/output.go
+++ b/output/output.go
@@ -69,7 +69,7 @@ func Stream(tests <-chan execute.TestResponse) Summary {
 func Summarize(summary Summary) {
 	fmt.Println("")
 	if summary.SuccessAmount > 0 {
-		fmt.Printf("%v successed\n", summary.SuccessAmount)
+		fmt.Printf("%v succeeded\n", summary.SuccessAmount)
 	}
 	if summary.FailAmount > 0 {
 		fmt.Printf("%v failed\n", summary.FailAmount)

--- a/output/output.go
+++ b/output/output.go
@@ -69,7 +69,7 @@ func Stream(tests <-chan execute.TestResponse) Summary {
 func Summarize(summary Summary) {
 	fmt.Println("")
 	if summary.SuccessAmount > 0 {
-		fmt.Printf("%v succeeded\n", summary.SuccessAmount)
+		fmt.Printf("%v passed\n", summary.SuccessAmount)
 	}
 	if summary.FailAmount > 0 {
 		fmt.Printf("%v failed\n", summary.FailAmount)

--- a/output/output.go
+++ b/output/output.go
@@ -42,7 +42,8 @@ type Summary struct {
 }
 
 // Stream results to the console, error at end if any fail
-func Stream(tests <-chan execute.TestResponse) (summary Summary) {
+func Stream(tests <-chan execute.TestResponse) Summary {
+	var summary Summary
 	for test := range tests {
 		for _, result := range test.Results {
 			var statStr string

--- a/output/stream.go
+++ b/output/stream.go
@@ -21,7 +21,6 @@
 package output
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/yarpc/crossdock/execute"
@@ -43,8 +42,7 @@ type Summary struct {
 }
 
 // Stream results to the console, error at end if any fail
-func Stream(tests <-chan execute.TestResponse) (summary Summary, err error) {
-	failed := false
+func Stream(tests <-chan execute.TestResponse) (summary Summary) {
 	for test := range tests {
 		for _, result := range test.Results {
 			var statStr string
@@ -57,17 +55,13 @@ func Stream(tests <-chan execute.TestResponse) (summary Summary, err error) {
 				summary.SkippedAmount++
 			default:
 				statStr = red("F")
-				failed = true
+				summary.Failed = true
 				summary.FailAmount++
 			}
 			fmt.Printf("%v - %v - %v\n", statStr, test.TestCase, result.Output)
 		}
 	}
-	if failed == true {
-		summary.Failed = true
-		return summary, errors.New("one or more tests failed")
-	}
-	return summary, nil
+	return summary
 }
 
 // Summarize outputs the summary to the console


### PR DESCRIPTION
Fixes #48 @yarpc/golang

Example output:

```
Crossdock starting...

Waiting on WAIT_FOR=[alpha omega]

HTTP: Service alpha:8080 is up
HTTP: Service omega:8080 is up

All services are up after 202.49757ms!

Executing Matrix...

✓ - {0xc820011470 alpha map[transport:http behavior:dance server:alpha]} - sup
✓ - {0xc820011470 alpha map[server:alpha transport:tchannel behavior:dance]} - sup
✓ - {0xc820011470 alpha map[transport:http behavior:dance server:omega]} - sup
✓ - {0xc820011470 alpha map[behavior:dance server:omega transport:tchannel]} - sup
S - {0xc820011470 omega map[behavior:dance server:alpha transport:http]} - sup
S - {0xc820011470 omega map[server:alpha transport:tchannel behavior:dance]} - sup
S - {0xc820011470 omega map[behavior:dance server:omega transport:http]} - sup
S - {0xc820011470 omega map[behavior:dance server:omega transport:tchannel]} - sup
✓ - {0xc820011470 alpha map[transport:http behavior:sing server:alpha]} - sup
✓ - {0xc820011470 alpha map[server:alpha transport:tchannel behavior:sing]} - sup
✓ - {0xc820011470 alpha map[behavior:sing server:omega transport:http]} - sup
✓ - {0xc820011470 alpha map[behavior:sing server:omega transport:tchannel]} - sup
S - {0xc820011470 omega map[behavior:sing server:alpha transport:http]} - sup
S - {0xc820011470 omega map[transport:tchannel behavior:sing server:alpha]} - sup
S - {0xc820011470 omega map[behavior:sing server:omega transport:http]} - sup
S - {0xc820011470 omega map[transport:tchannel behavior:sing server:omega]} - sup

8 passed
8 skipped

Tests passed!
```
