### PR TITLE
Allow multiple console reporters

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ crossdock:
         - omega
     environment:
       - WAIT_FOR=alpha,omega
+      - REPORT=list
 
       - AXIS_CLIENT=alpha,omega
       - AXIS_SERVER=alpha,omega

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,6 @@ crossdock:
         - omega
     environment:
       - WAIT_FOR=alpha,omega
-      - REPORT=list
 
       - AXIS_CLIENT=alpha,omega
       - AXIS_SERVER=alpha,omega

--- a/main.go
+++ b/main.go
@@ -46,7 +46,7 @@ func main() {
 	fmt.Printf("\nExecuting Matrix...\n\n")
 	results := execute.Run(plan)
 
-	reporter := output.GetReporter("list")
+	reporter := output.GetReporter(config.Report)
 	summary := reporter.Stream(results)
 	output.Summarize(summary)
 

--- a/main.go
+++ b/main.go
@@ -46,7 +46,11 @@ func main() {
 	fmt.Printf("\nExecuting Matrix...\n\n")
 	results := execute.Run(plan)
 
-	reporter := output.GetReporter(config.Report)
+	reporter, err := output.GetReporter(config.Report)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 	summary := reporter.Stream(results)
 	output.Summarize(summary)
 

--- a/output/list.go
+++ b/output/list.go
@@ -18,39 +18,40 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 // THE SOFTWARE.
 
-package main
+package output
 
 import (
 	"fmt"
-	"log"
-	"os"
-	"time"
 
 	"github.com/yarpc/crossdock/execute"
-	"github.com/yarpc/crossdock/output"
-	"github.com/yarpc/crossdock/plan"
+
+	"github.com/fatih/color"
 )
 
-func main() {
-	fmt.Printf("\nCrossdock starting...\n\n")
+var green = color.New(color.FgGreen).SprintFunc()
+var yellow = color.New(color.FgYellow).SprintFunc()
+var red = color.New(color.FgRed).SprintFunc()
 
-	config, err := plan.ReadConfigFromEnviron()
-	if err != nil {
-		log.Fatal(err)
+// List is a ReporterFunc that produces a verbose list of results
+func List(tests <-chan execute.TestResponse) Summary {
+	var summary Summary
+	for test := range tests {
+		for _, result := range test.Results {
+			var statStr string
+			switch result.Status {
+			case execute.Success:
+				statStr = green("✓")
+				summary.SuccessAmount++
+			case execute.Skipped:
+				statStr = yellow("S")
+				summary.SkippedAmount++
+			default:
+				statStr = red("F")
+				summary.Failed = true
+				summary.FailAmount++
+			}
+			fmt.Printf("%v - %v - %v\n", statStr, test.TestCase, result.Output)
+		}
 	}
-	plan := plan.New(config)
-
-	fmt.Printf("Waiting on WAIT_FOR=%v\n\n", plan.Config.WaitForHosts)
-	execute.Wait(plan.Config.WaitForHosts, time.Duration(30)*time.Second)
-
-	fmt.Printf("\nExecuting Matrix...\n\n")
-	results := execute.Run(plan)
-
-	reporter := output.GetReporter("list")
-	summary := reporter.Stream(results)
-	output.Summarize(summary)
-
-	if summary.Failed == true {
-		os.Exit(1)
-	}
+	return summary
 }

--- a/output/list.go
+++ b/output/list.go
@@ -33,7 +33,7 @@ var yellow = color.New(color.FgYellow).SprintFunc()
 var red = color.New(color.FgRed).SprintFunc()
 
 // List is a ReporterFunc that produces a verbose list of results
-func List(tests <-chan execute.TestResponse) Summary {
+var List ReporterFunc = func(tests <-chan execute.TestResponse) Summary {
 	var summary Summary
 	for test := range tests {
 		for _, result := range test.Results {

--- a/output/list.go
+++ b/output/list.go
@@ -41,14 +41,14 @@ func List(tests <-chan execute.TestResponse) Summary {
 			switch result.Status {
 			case execute.Success:
 				statStr = green("✓")
-				summary.SuccessAmount++
+				summary.NumSuccess++
 			case execute.Skipped:
 				statStr = yellow("S")
-				summary.SkippedAmount++
+				summary.NumSkipped++
 			default:
 				statStr = red("F")
 				summary.Failed = true
-				summary.FailAmount++
+				summary.NumFail++
 			}
 			fmt.Printf("%v - %v - %v\n", statStr, test.TestCase, result.Output)
 		}

--- a/output/report.go
+++ b/output/report.go
@@ -30,7 +30,7 @@ type Reporter interface {
 // ReporterFunc streams test results to the console
 type ReporterFunc func(tests <-chan execute.TestResponse) Summary
 
-// Stream outputs test results to the console
+// Stream allows ReporterFunc to fulfill the Reporter interface
 func (f ReporterFunc) Stream(tests <-chan execute.TestResponse) Summary {
 	return f(tests)
 }

--- a/output/report.go
+++ b/output/report.go
@@ -20,7 +20,11 @@
 
 package output
 
-import "github.com/yarpc/crossdock/execute"
+import (
+	"fmt"
+
+	"github.com/yarpc/crossdock/execute"
+)
 
 // Reporter is responsible for outputting test results
 type Reporter interface {
@@ -36,6 +40,16 @@ func (f ReporterFunc) Stream(tests <-chan execute.TestResponse) Summary {
 }
 
 // GetReporter returns a ReporterFunc for the given name
-func GetReporter(name string) Reporter {
-	return ReporterFunc(List)
+func GetReporter(name string) (Reporter, error) {
+	// default reporter
+	if name == "" {
+		return ReporterFunc(List), nil
+	}
+	// else a specific value was provided
+	switch name {
+	case "list":
+		return ReporterFunc(List), nil
+	default:
+		return nil, fmt.Errorf("%v is not a valid reporter", name)
+	}
 }

--- a/output/report.go
+++ b/output/report.go
@@ -43,12 +43,12 @@ func (f ReporterFunc) Stream(tests <-chan execute.TestResponse) Summary {
 func GetReporter(name string) (Reporter, error) {
 	// default reporter
 	if name == "" {
-		return ReporterFunc(List), nil
+		return List, nil
 	}
 	// else a specific value was provided
 	switch name {
 	case "list":
-		return ReporterFunc(List), nil
+		return List, nil
 	default:
 		return nil, fmt.Errorf("%v is not a valid reporter", name)
 	}

--- a/output/summary.go
+++ b/output/summary.go
@@ -26,22 +26,22 @@ import "fmt"
 type Summary struct {
 	Failed bool
 
-	SuccessAmount int
-	FailAmount    int
-	SkippedAmount int
+	NumSuccess int
+	NumFail    int
+	NumSkipped int
 }
 
 // Summarize outputs the summary to the console
 func Summarize(summary Summary) {
 	fmt.Println("")
-	if summary.SuccessAmount > 0 {
-		fmt.Printf("%v passed\n", summary.SuccessAmount)
+	if summary.NumSuccess > 0 {
+		fmt.Printf("%v passed\n", summary.NumSuccess)
 	}
-	if summary.FailAmount > 0 {
-		fmt.Printf("%v failed\n", summary.FailAmount)
+	if summary.NumFail > 0 {
+		fmt.Printf("%v failed\n", summary.NumFail)
 	}
-	if summary.SkippedAmount > 0 {
-		fmt.Printf("%v skipped\n", summary.SkippedAmount)
+	if summary.NumSkipped > 0 {
+		fmt.Printf("%v skipped\n", summary.NumSkipped)
 	}
 
 	if summary.Failed == true {

--- a/output/summary.go
+++ b/output/summary.go
@@ -20,17 +20,7 @@
 
 package output
 
-import (
-	"fmt"
-
-	"github.com/yarpc/crossdock/execute"
-
-	"github.com/fatih/color"
-)
-
-var green = color.New(color.FgGreen).SprintFunc()
-var yellow = color.New(color.FgYellow).SprintFunc()
-var red = color.New(color.FgRed).SprintFunc()
+import "fmt"
 
 // Summary contains an account of the test run
 type Summary struct {
@@ -39,30 +29,6 @@ type Summary struct {
 	SuccessAmount int
 	FailAmount    int
 	SkippedAmount int
-}
-
-// Stream results to the console, error at end if any fail
-func Stream(tests <-chan execute.TestResponse) Summary {
-	var summary Summary
-	for test := range tests {
-		for _, result := range test.Results {
-			var statStr string
-			switch result.Status {
-			case execute.Success:
-				statStr = green("✓")
-				summary.SuccessAmount++
-			case execute.Skipped:
-				statStr = yellow("S")
-				summary.SkippedAmount++
-			default:
-				statStr = red("F")
-				summary.Failed = true
-				summary.FailAmount++
-			}
-			fmt.Printf("%v - %v - %v\n", statStr, test.TestCase, result.Output)
-		}
-	}
-	return summary
 }
 
 // Summarize outputs the summary to the console

--- a/plan/config.go
+++ b/plan/config.go
@@ -43,7 +43,7 @@ func ReadConfigFromEnviron() (*Config, error) {
 		callTimeout = defaultCallTimeout
 	}
 
-	WaitForHosts := trimCollection(strings.Split(os.Getenv(waitKey), ","))
+	waitForHosts := trimCollection(strings.Split(os.Getenv(waitKey), ","))
 	axes := make(map[string]Axis)
 	behaviors := make(map[string]Behavior)
 	for _, e := range os.Environ() {
@@ -57,7 +57,7 @@ func ReadConfigFromEnviron() (*Config, error) {
 	}
 	config := &Config{
 		CallTimeout:  time.Duration(callTimeout),
-		WaitForHosts: WaitForHosts,
+		WaitForHosts: waitForHosts,
 		Axes:         axes,
 		Behaviors:    behaviors,
 	}

--- a/plan/config.go
+++ b/plan/config.go
@@ -58,7 +58,7 @@ func ReadConfigFromEnviron() (*Config, error) {
 		}
 	}
 	config := &Config{
-		Report:       os.Getenv(reportKey),
+		Report:       strings.ToLower(os.Getenv(reportKey)),
 		CallTimeout:  time.Duration(callTimeout),
 		WaitForHosts: waitForHosts,
 		Axes:         axes,

--- a/plan/config.go
+++ b/plan/config.go
@@ -33,11 +33,13 @@ const defaultCallTimeout = 5
 // ReadConfigFromEnviron creates a Config by looking for environment variables
 func ReadConfigFromEnviron() (*Config, error) {
 	const (
+		reportKey         = "REPORT"
 		callTimeoutKey    = "CALL_TIMEOUT"
 		waitKey           = "WAIT_FOR"
 		axisKeyPrefix     = "AXIS_"
 		behaviorKeyPrefix = "BEHAVIOR_"
 	)
+
 	callTimeout, _ := strconv.Atoi(os.Getenv(callTimeoutKey))
 	if callTimeout == 0 {
 		callTimeout = defaultCallTimeout
@@ -56,6 +58,7 @@ func ReadConfigFromEnviron() (*Config, error) {
 		}
 	}
 	config := &Config{
+		Report:       os.Getenv(reportKey),
 		CallTimeout:  time.Duration(callTimeout),
 		WaitForHosts: waitForHosts,
 		Axes:         axes,

--- a/plan/config_test.go
+++ b/plan/config_test.go
@@ -28,6 +28,7 @@ import (
 )
 
 func TestReadConfigFromEnviron(t *testing.T) {
+	os.Setenv("REPORT", "list")
 	os.Setenv("AXIS_CLIENT", "yarpc-go,yarpc-node,yarpc-browser")
 	os.Setenv("AXIS_SERVER", "yarpc-go,yarpc-node")
 	os.Setenv("AXIS_TRANSPORT", "http,tchannel")
@@ -40,6 +41,8 @@ func TestReadConfigFromEnviron(t *testing.T) {
 	client := Axis{Name: "client", Values: []string{"yarpc-go", "yarpc-node", "yarpc-browser"}}
 	server := Axis{Name: "server", Values: []string{"yarpc-go", "yarpc-node"}}
 	transport := Axis{Name: "transport", Values: []string{"http", "tchannel"}}
+
+	assert.Equal(t, config.Report, "list")
 
 	assert.Equal(t, config.Axes, map[string]Axis{
 		"client":    client,

--- a/plan/entities.go
+++ b/plan/entities.go
@@ -27,6 +27,7 @@ import (
 
 // Config describes the unstructured test plan
 type Config struct {
+	Report       string
 	CallTimeout  time.Duration
 	WaitForHosts []string
 	Axes         map[string]Axis


### PR DESCRIPTION
Setting `REPORT` to a valid reporter value will result in a different console reporter.

The default is `list`, and `REPORT` is optional.

This paves the way for #51 

@yarpc/golang 
