### PR TITLE
Remove channels from the reporter interface

### DIFF
--- a/main.go
+++ b/main.go
@@ -52,11 +52,19 @@ func main() {
 		os.Exit(1)
 	}
 
-	reporter.Start(config)
+	err = reporter.Start(config)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 	for test := range results {
 		reporter.Next(test, config)
 	}
-	summary := reporter.End(config)
+	summary, err := reporter.End(config)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 	output.Summarize(summary)
 
 	if summary.Failed == true {

--- a/main.go
+++ b/main.go
@@ -51,7 +51,12 @@ func main() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	summary := reporter.Stream(config, results)
+
+	reporter.Start(config)
+	for test := range results {
+		reporter.Next(test, config)
+	}
+	summary := reporter.End(config)
 	output.Summarize(summary)
 
 	if summary.Failed == true {

--- a/output/list.go
+++ b/output/list.go
@@ -33,26 +33,32 @@ var green = color.New(color.FgGreen).SprintFunc()
 var yellow = color.New(color.FgYellow).SprintFunc()
 var red = color.New(color.FgRed).SprintFunc()
 
-// List is a ReporterFunc that produces a verbose list of results
-var List ReporterFunc = func(config *plan.Config, tests <-chan execute.TestResponse) Summary {
-	var summary Summary
-	for test := range tests {
-		for _, result := range test.Results {
-			var statStr string
-			switch result.Status {
-			case execute.Success:
-				statStr = green("✓")
-				summary.NumSuccess++
-			case execute.Skipped:
-				statStr = yellow("S")
-				summary.NumSkipped++
-			default:
-				statStr = red("F")
-				summary.Failed = true
-				summary.NumFail++
-			}
-			fmt.Printf("%v - %v - %v\n", statStr, test.TestCase, result.Output)
+type List struct {
+	Summary Summary
+}
+
+func (l *List) Start(config *plan.Config) {
+}
+
+func (l *List) Next(test execute.TestResponse, config *plan.Config) {
+	for _, result := range test.Results {
+		var statStr string
+		switch result.Status {
+		case execute.Success:
+			statStr = green("✓")
+			l.Summary.NumSuccess++
+		case execute.Skipped:
+			statStr = yellow("S")
+			l.Summary.NumSkipped++
+		default:
+			statStr = red("F")
+			l.Summary.Failed = true
+			l.Summary.NumFail++
 		}
+		fmt.Printf("%v - %v - %v\n", statStr, test.TestCase, result.Output)
 	}
-	return summary
+}
+
+func (l *List) End(config *plan.Config) Summary {
+	return l.Summary
 }

--- a/output/list.go
+++ b/output/list.go
@@ -37,7 +37,8 @@ type List struct {
 	Summary Summary
 }
 
-func (l *List) Start(config *plan.Config) {
+func (l *List) Start(config *plan.Config) error {
+	return nil
 }
 
 func (l *List) Next(test execute.TestResponse, config *plan.Config) {
@@ -59,6 +60,6 @@ func (l *List) Next(test execute.TestResponse, config *plan.Config) {
 	}
 }
 
-func (l *List) End(config *plan.Config) Summary {
-	return l.Summary
+func (l *List) End(config *plan.Config) (Summary, error) {
+	return l.Summary, nil
 }

--- a/output/report.go
+++ b/output/report.go
@@ -29,9 +29,9 @@ import (
 
 // Reporter is responsible for outputting test results
 type Reporter interface {
-	Start(config *plan.Config)
+	Start(config *plan.Config) error
 	Next(response execute.TestResponse, config *plan.Config)
-	End(config *plan.Config) Summary
+	End(config *plan.Config) (Summary, error)
 }
 
 // GetReporter returns a ReporterFunc for the given name

--- a/output/report.go
+++ b/output/report.go
@@ -29,29 +29,23 @@ import (
 
 // Reporter is responsible for outputting test results
 type Reporter interface {
-	Stream(config *plan.Config, tests <-chan execute.TestResponse) Summary
-}
-
-// ReporterFunc streams test results to the console
-type ReporterFunc func(config *plan.Config, tests <-chan execute.TestResponse) Summary
-
-// Stream allows ReporterFunc to fulfill the Reporter interface
-func (f ReporterFunc) Stream(config *plan.Config, tests <-chan execute.TestResponse) Summary {
-	return f(config, tests)
+	Start(config *plan.Config)
+	Next(response execute.TestResponse, config *plan.Config)
+	End(config *plan.Config) Summary
 }
 
 // GetReporter returns a ReporterFunc for the given name
 func GetReporter(name string) (Reporter, error) {
 	// default reporter
 	if name == "" {
-		return List, nil
+		return &List{}, nil
 	}
 	// else a specific value was provided
 	switch name {
 	case "list":
-		return List, nil
+		return &List{}, nil
 	case "json":
-		return JSON, nil
+		return &JSON{}, nil
 	default:
 		return nil, fmt.Errorf("%v is not a valid reporter", name)
 	}

--- a/plan/config.go
+++ b/plan/config.go
@@ -61,9 +61,6 @@ func ReadConfigFromEnviron() (*Config, error) {
 	}
 
 	jsonReportPath := os.Getenv(jsonReportPathKey)
-	if jsonReportPath == "" {
-		jsonReportPath = "/crossdock/report.json"
-	}
 
 	config := &Config{
 		Report:         strings.ToLower(os.Getenv(reportKey)),


### PR DESCRIPTION
This is to pave the way for multiplexing reporters without having to use concurrency in the mux layer.

Intend to rebase after #54 lands.
