### PR TITLE
Omnibus diff for multiple reporters

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ crossdock:
       - BEHAVIOR_DANCE=client,server,transport
       - BEHAVIOR_SING=client,server,transport
 
-      - REPORT=json
+      - REPORT=list,json
       - JSON_REPORT_PATH=/crossdock/report.json
 
     volumes:

--- a/execute/entities.go
+++ b/execute/entities.go
@@ -62,7 +62,7 @@ func (s Status) String() string {
 	case Skipped:
 		return "skipped"
 	default:
-		return fmt.Sprintf("Status(%v)", s)
+		return fmt.Sprintf("Status(%d)", int(s))
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -46,21 +46,23 @@ func main() {
 	fmt.Printf("\nExecuting Matrix...\n\n")
 	results := execute.Run(plan)
 
-	reporter, err := output.GetReporter(config.Reports)
-	if err != nil {
+	fail := func(err error) {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
+	reporter, err := output.GetReporter(config.Reports)
+	if err != nil {
+		fail(err)
+	}
+
 	if err = reporter.Start(config); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		fail(err)
 	}
 	for test := range results {
 		reporter.Next(test)
 	}
 	if err := reporter.End(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		fail(err)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -52,11 +52,19 @@ func main() {
 		os.Exit(1)
 	}
 
-	reporter.Start(config)
+	err = reporter.Start(config)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 	for test := range results {
 		reporter.Next(test, config)
 	}
-	summary := reporter.End(config)
+	summary, err := reporter.End(config)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 	output.Summarize(summary)
 
 	if summary.Failed == true {

--- a/main.go
+++ b/main.go
@@ -46,28 +46,21 @@ func main() {
 	fmt.Printf("\nExecuting Matrix...\n\n")
 	results := execute.Run(plan)
 
-	reporter, err := output.GetReporter(config.Report)
+	reporter, err := output.GetReporter(config.Reports)
 	if err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 
-	err = reporter.Start(config)
-	if err != nil {
+	if err = reporter.Start(config); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}
 	for test := range results {
-		reporter.Next(test, config)
+		reporter.Next(test)
 	}
-	summary, err := reporter.End(config)
-	if err != nil {
+	if err := reporter.End(); err != nil {
 		fmt.Println(err)
-		os.Exit(1)
-	}
-	output.Summarize(summary)
-
-	if summary.Failed == true {
 		os.Exit(1)
 	}
 }

--- a/main.go
+++ b/main.go
@@ -51,7 +51,12 @@ func main() {
 		fmt.Println(err)
 		os.Exit(1)
 	}
-	summary := reporter.Stream(config, results)
+
+	reporter.Start(config)
+	for test := range results {
+		reporter.Next(test, config)
+	}
+	summary := reporter.End(config)
 	output.Summarize(summary)
 
 	if summary.Failed == true {

--- a/output/json.go
+++ b/output/json.go
@@ -26,16 +26,16 @@ type JSONReport struct {
 }
 
 type JSON struct {
-	r    JSONReport
-	path string
+	report JSONReport
+	path   string
 }
 
 func (j *JSON) Start(config *plan.Config) error {
 	j.path = config.JSONReportPath
-	j.r.Behaviors = make(map[string]*JSONBehaviorReport)
+	j.report.Behaviors = make(map[string]*JSONBehaviorReport)
 
 	if config.JSONReportPath == "" {
-		return fmt.Errorf("JSON_REPORT_PATH is a required environment varialbe for REPORT=json")
+		return fmt.Errorf("JSON_REPORT_PATH is a required environment variable for REPORT=json")
 	}
 
 	for _, behavior := range config.Behaviors {
@@ -43,7 +43,7 @@ func (j *JSON) Start(config *plan.Config) error {
 			Tests:  make([]JSONTestReport, 0, 10),
 			Params: behavior.Params,
 		}
-		j.r.Behaviors[behavior.Name] = behaviorReport
+		j.report.Behaviors[behavior.Name] = behaviorReport
 	}
 
 	return nil
@@ -54,7 +54,7 @@ func (j *JSON) Next(test execute.TestResponse) {
 	args := test.TestCase.Arguments
 	behavior := test.TestCase.Arguments["behavior"]
 	delete(args, "behavior")
-	behaviorReport := j.r.Behaviors[behavior]
+	behaviorReport := j.report.Behaviors[behavior]
 	if behaviorReport == nil {
 		return
 	}
@@ -69,7 +69,7 @@ func (j *JSON) Next(test execute.TestResponse) {
 }
 
 func (j *JSON) End() error {
-	data, err := json.Marshal(j.r)
+	data, err := json.Marshal(j.report)
 	if err != nil {
 		return err
 	}

--- a/output/json.go
+++ b/output/json.go
@@ -26,11 +26,12 @@ type JSONReport struct {
 }
 
 type JSON struct {
-	s Summary
-	r JSONReport
+	r    JSONReport
+	path string
 }
 
 func (j *JSON) Start(config *plan.Config) error {
+	j.path = config.JSONReportPath
 	j.r.Behaviors = make(map[string]*JSONBehaviorReport)
 
 	if config.JSONReportPath == "" {
@@ -48,7 +49,7 @@ func (j *JSON) Start(config *plan.Config) error {
 	return nil
 }
 
-func (j *JSON) Next(test execute.TestResponse, config *plan.Config) {
+func (j *JSON) Next(test execute.TestResponse) {
 	client := test.TestCase.Client
 	args := test.TestCase.Arguments
 	behavior := test.TestCase.Arguments["behavior"]
@@ -67,16 +68,15 @@ func (j *JSON) Next(test execute.TestResponse, config *plan.Config) {
 	}
 }
 
-func (j *JSON) End(config *plan.Config) (Summary, error) {
+func (j *JSON) End() error {
 	data, err := json.Marshal(j.r)
 	if err != nil {
-		return j.s, err
+		return err
 	}
 
-	err = ioutil.WriteFile(config.JSONReportPath, data, 0644)
-	if err != nil {
-		return j.s, err
+	if err = ioutil.WriteFile(j.path, data, 0644); err != nil {
+		return err
 	}
 
-	return j.s, nil
+	return nil
 }

--- a/output/list.go
+++ b/output/list.go
@@ -33,26 +33,32 @@ var green = color.New(color.FgGreen).SprintFunc()
 var yellow = color.New(color.FgYellow).SprintFunc()
 var red = color.New(color.FgRed).SprintFunc()
 
-// List is a ReporterFunc that produces a verbose list of results
-var List ReporterFunc = func(config *plan.Config, tests <-chan execute.TestResponse) Summary {
-	var summary Summary
-	for test := range tests {
-		for _, result := range test.Results {
-			var statStr string
-			switch result.Status {
-			case execute.Success:
-				statStr = green("✓")
-				summary.NumSuccess++
-			case execute.Skipped:
-				statStr = yellow("S")
-				summary.NumSkipped++
-			default:
-				statStr = red("F")
-				summary.Failed = true
-				summary.NumFail++
-			}
-			fmt.Printf("%v - %v - %v\n", statStr, test.TestCase, result.Output)
+type List struct {
+	Summary Summary
+}
+
+func (l *List) Start(config *plan.Config) {
+}
+
+func (l *List) Next(test execute.TestResponse, config *plan.Config) {
+	for _, result := range test.Results {
+		var statStr string
+		switch result.Status {
+		case execute.Success:
+			statStr = green("✓")
+			l.Summary.NumSuccess++
+		case execute.Skipped:
+			statStr = yellow("S")
+			l.Summary.NumSkipped++
+		default:
+			statStr = red("F")
+			l.Summary.Failed = true
+			l.Summary.NumFail++
 		}
+		fmt.Printf("%v - %v - %v\n", statStr, test.TestCase, result.Output)
 	}
-	return summary
+}
+
+func (l *List) End(config *plan.Config) Summary {
+	return l.Summary
 }

--- a/output/list.go
+++ b/output/list.go
@@ -34,32 +34,27 @@ var yellow = color.New(color.FgYellow).SprintFunc()
 var red = color.New(color.FgRed).SprintFunc()
 
 type List struct {
-	Summary Summary
 }
 
 func (l *List) Start(config *plan.Config) error {
 	return nil
 }
 
-func (l *List) Next(test execute.TestResponse, config *plan.Config) {
+func (l *List) Next(test execute.TestResponse) {
 	for _, result := range test.Results {
 		var statStr string
 		switch result.Status {
 		case execute.Success:
 			statStr = green("✓")
-			l.Summary.NumSuccess++
 		case execute.Skipped:
 			statStr = yellow("S")
-			l.Summary.NumSkipped++
 		default:
 			statStr = red("F")
-			l.Summary.Failed = true
-			l.Summary.NumFail++
 		}
 		fmt.Printf("%v - %v - %v\n", statStr, test.TestCase, result.Output)
 	}
 }
 
-func (l *List) End(config *plan.Config) (Summary, error) {
-	return l.Summary, nil
+func (l *List) End() error {
+	return nil
 }

--- a/output/list.go
+++ b/output/list.go
@@ -37,7 +37,8 @@ type List struct {
 	Summary Summary
 }
 
-func (l *List) Start(config *plan.Config) {
+func (l *List) Start(config *plan.Config) error {
+	return nil
 }
 
 func (l *List) Next(test execute.TestResponse, config *plan.Config) {
@@ -59,6 +60,6 @@ func (l *List) Next(test execute.TestResponse, config *plan.Config) {
 	}
 }
 
-func (l *List) End(config *plan.Config) Summary {
-	return l.Summary
+func (l *List) End(config *plan.Config) (Summary, error) {
+	return l.Summary, nil
 }

--- a/output/list.go
+++ b/output/list.go
@@ -33,14 +33,15 @@ var green = color.New(color.FgGreen).SprintFunc()
 var yellow = color.New(color.FgYellow).SprintFunc()
 var red = color.New(color.FgRed).SprintFunc()
 
-type List struct {
-}
+type list struct{}
 
-func (l *List) Start(config *plan.Config) error {
+var List list
+
+func (list) Start(config *plan.Config) error {
 	return nil
 }
 
-func (l *List) Next(test execute.TestResponse) {
+func (list) Next(test execute.TestResponse) {
 	for _, result := range test.Results {
 		var statStr string
 		switch result.Status {
@@ -55,6 +56,6 @@ func (l *List) Next(test execute.TestResponse) {
 	}
 }
 
-func (l *List) End() error {
+func (list) End() error {
 	return nil
 }

--- a/output/mux.go
+++ b/output/mux.go
@@ -1,0 +1,38 @@
+package output
+
+import (
+	"github.com/yarpc/crossdock/execute"
+	"github.com/yarpc/crossdock/plan"
+)
+
+type Mux struct {
+	s         Summary
+	Reporters []Reporter
+}
+
+func (r Mux) Start(config *plan.Config) error {
+	for _, reporter := range r.Reporters {
+		err := reporter.Start(config)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (r Mux) Next(response execute.TestResponse, config *plan.Config) {
+	for _, reporter := range r.Reporters {
+		reporter.Next(response, config)
+	}
+}
+
+func (r Mux) End(config *plan.Config) (Summary, error) {
+	var summary Summary
+	for _, reporter := range r.Reporters {
+		summary, err := reporter.End(config)
+		if err != nil {
+			return summary, err
+		}
+	}
+	return summary, nil
+}

--- a/output/mux.go
+++ b/output/mux.go
@@ -6,33 +6,29 @@ import (
 )
 
 type Mux struct {
-	s         Summary
 	Reporters []Reporter
 }
 
 func (r Mux) Start(config *plan.Config) error {
 	for _, reporter := range r.Reporters {
-		err := reporter.Start(config)
-		if err != nil {
+		if err := reporter.Start(config); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (r Mux) Next(response execute.TestResponse, config *plan.Config) {
+func (r Mux) Next(response execute.TestResponse) {
 	for _, reporter := range r.Reporters {
-		reporter.Next(response, config)
+		reporter.Next(response)
 	}
 }
 
-func (r Mux) End(config *plan.Config) (Summary, error) {
-	var summary Summary
+func (r Mux) End() error {
 	for _, reporter := range r.Reporters {
-		summary, err := reporter.End(config)
-		if err != nil {
-			return summary, err
+		if err := reporter.End(); err != nil {
+			return err
 		}
 	}
-	return summary, nil
+	return nil
 }

--- a/output/mux.go
+++ b/output/mux.go
@@ -5,12 +5,10 @@ import (
 	"github.com/yarpc/crossdock/plan"
 )
 
-type Mux struct {
-	Reporters []Reporter
-}
+type Mux []Reporter
 
 func (r Mux) Start(config *plan.Config) error {
-	for _, reporter := range r.Reporters {
+	for _, reporter := range r {
 		if err := reporter.Start(config); err != nil {
 			return err
 		}
@@ -19,13 +17,13 @@ func (r Mux) Start(config *plan.Config) error {
 }
 
 func (r Mux) Next(response execute.TestResponse) {
-	for _, reporter := range r.Reporters {
+	for _, reporter := range r {
 		reporter.Next(response)
 	}
 }
 
 func (r Mux) End() error {
-	for _, reporter := range r.Reporters {
+	for _, reporter := range r {
 		if err := reporter.End(); err != nil {
 			return err
 		}

--- a/output/report.go
+++ b/output/report.go
@@ -29,9 +29,9 @@ import (
 
 // Reporter is responsible for outputting test results
 type Reporter interface {
-	Start(config *plan.Config)
+	Start(config *plan.Config) error
 	Next(response execute.TestResponse, config *plan.Config)
-	End(config *plan.Config) Summary
+	End(config *plan.Config) (Summary, error)
 }
 
 // GetReporter returns a ReporterFunc for the given name

--- a/output/report.go
+++ b/output/report.go
@@ -46,6 +46,15 @@ func GetReporter(name string) (Reporter, error) {
 		return &List{}, nil
 	case "json":
 		return &JSON{}, nil
+	case "list,json":
+		fallthrough
+	case "json,list":
+		return &Mux{
+			Reporters: []Reporter{
+				&List{},
+				&JSON{},
+			},
+		}, nil
 	default:
 		return nil, fmt.Errorf("%v is not a valid reporter", name)
 	}

--- a/output/report.go
+++ b/output/report.go
@@ -29,29 +29,23 @@ import (
 
 // Reporter is responsible for outputting test results
 type Reporter interface {
-	Stream(config *plan.Config, tests <-chan execute.TestResponse) Summary
-}
-
-// ReporterFunc streams test results to the console
-type ReporterFunc func(config *plan.Config, tests <-chan execute.TestResponse) Summary
-
-// Stream allows ReporterFunc to fulfill the Reporter interface
-func (f ReporterFunc) Stream(config *plan.Config, tests <-chan execute.TestResponse) Summary {
-	return f(config, tests)
+	Start(config *plan.Config)
+	Next(response execute.TestResponse, config *plan.Config)
+	End(config *plan.Config) Summary
 }
 
 // GetReporter returns a ReporterFunc for the given name
 func GetReporter(name string) (Reporter, error) {
 	// default reporter
 	if name == "" {
-		return List, nil
+		return &List{}, nil
 	}
 	// else a specific value was provided
 	switch name {
 	case "list":
-		return List, nil
+		return &List{}, nil
 	case "json":
-		return JSON, nil
+		return &JSON{}, nil
 	default:
 		return nil, fmt.Errorf("%v is not a valid reporter", name)
 	}

--- a/output/report.go
+++ b/output/report.go
@@ -40,18 +40,18 @@ func GetReporter(names []string) (Reporter, error) {
 	if len(names) == 0 {
 		names = append(names, "list")
 	}
-	reporters := []Reporter{}
+	var mux Mux
 	for _, name := range names {
 		switch name {
 		case "list":
-			reporters = append(reporters, &List{})
+			mux = append(mux, List)
 		case "json":
-			reporters = append(reporters, &JSON{})
+			mux = append(mux, &JSON{})
 		default:
 			return nil, fmt.Errorf("%v is not a valid reporter", name)
 		}
 	}
 	summary := &Summary{}
-	reporters = append(reporters, summary)
-	return &Mux{Reporters: reporters}, nil
+	mux = append(mux, summary)
+	return mux, nil
 }

--- a/output/summary.go
+++ b/output/summary.go
@@ -20,7 +20,12 @@
 
 package output
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/yarpc/crossdock/execute"
+	"github.com/yarpc/crossdock/plan"
+)
 
 // Summary contains an account of the test run
 type Summary struct {
@@ -31,22 +36,41 @@ type Summary struct {
 	NumSkipped int
 }
 
+func (s *Summary) Start(config *plan.Config) error {
+	return nil
+}
+
+func (s *Summary) Next(test execute.TestResponse) {
+	for _, result := range test.Results {
+		switch result.Status {
+		case execute.Success:
+			s.NumSuccess++
+		case execute.Skipped:
+			s.NumSkipped++
+		default:
+			s.Failed = true
+			s.NumFail++
+		}
+	}
+}
+
 // Summarize outputs the summary to the console
-func Summarize(summary Summary) {
+func (s *Summary) End() error {
 	fmt.Println("")
-	if summary.NumSuccess > 0 {
-		fmt.Printf("%v passed\n", summary.NumSuccess)
+	if s.NumSuccess > 0 {
+		fmt.Printf("%v passed\n", s.NumSuccess)
 	}
-	if summary.NumFail > 0 {
-		fmt.Printf("%v failed\n", summary.NumFail)
+	if s.NumFail > 0 {
+		fmt.Printf("%v failed\n", s.NumFail)
 	}
-	if summary.NumSkipped > 0 {
-		fmt.Printf("%v skipped\n", summary.NumSkipped)
+	if s.NumSkipped > 0 {
+		fmt.Printf("%v skipped\n", s.NumSkipped)
 	}
 
-	if summary.Failed == true {
+	if s.Failed {
 		fmt.Printf("\nTests did not pass!\n\n")
-		return
+		return nil
 	}
 	fmt.Printf("\nTests passed!\n\n")
+	return nil
 }

--- a/plan/config.go
+++ b/plan/config.go
@@ -47,6 +47,7 @@ func ReadConfigFromEnviron() (*Config, error) {
 	}
 
 	waitForHosts := trimCollection(strings.Split(os.Getenv(waitKey), ","))
+	reports := trimCollection(strings.Split(strings.ToLower(os.Getenv(reportKey)), ","))
 
 	axes := make(map[string]Axis)
 	behaviors := make(map[string]Behavior)
@@ -63,7 +64,7 @@ func ReadConfigFromEnviron() (*Config, error) {
 	jsonReportPath := os.Getenv(jsonReportPathKey)
 
 	config := &Config{
-		Report:         strings.ToLower(os.Getenv(reportKey)),
+		Reports:        reports,
 		CallTimeout:    time.Duration(callTimeout),
 		WaitForHosts:   waitForHosts,
 		Axes:           axes,
@@ -120,9 +121,12 @@ func validateConfig(config *Config) error {
 }
 
 func trimCollection(in []string) []string {
-	ret := make([]string, len(in))
-	for i, v := range in {
-		ret[i] = strings.Trim(v, " ")
+	ret := make([]string, 0, len(in))
+	for _, v := range in {
+		if v == "" {
+			continue
+		}
+		ret = append(ret, strings.Trim(v, " "))
 	}
 	return ret
 }

--- a/plan/config.go
+++ b/plan/config.go
@@ -61,9 +61,6 @@ func ReadConfigFromEnviron() (*Config, error) {
 	}
 
 	jsonReportPath := os.Getenv(jsonReportPathKey)
-	if jsonReportPath == "" {
-		jsonReportPath = "/crossdock/report.json"
-	}
 
 	config := &Config{
 		Report:         strings.ToLower(os.Getenv(reportKey)),

--- a/plan/config_test.go
+++ b/plan/config_test.go
@@ -42,7 +42,7 @@ func TestReadConfigFromEnviron(t *testing.T) {
 	server := Axis{Name: "server", Values: []string{"yarpc-go", "yarpc-node"}}
 	transport := Axis{Name: "transport", Values: []string{"http", "tchannel"}}
 
-	assert.Equal(t, config.Report, "list")
+	assert.Equal(t, config.Reports, []string{"list"})
 
 	assert.Equal(t, config.Axes, map[string]Axis{
 		"client":    client,

--- a/plan/entities.go
+++ b/plan/entities.go
@@ -27,7 +27,7 @@ import (
 
 // Config describes the unstructured test plan
 type Config struct {
-	Report         string
+	Reports        []string
 	CallTimeout    time.Duration
 	WaitForHosts   []string
 	Axes           map[string]Axis


### PR DESCRIPTION
Turns the summary into a reporter instance and factors it out of the JSON/List reporters. Includes the refactor from stream to {Start, Next, End} synchronous reporters.
