### PR TITLE
Limit DNS search to absolute hostnames.

### DIFF
--- a/docker-compose-fail.yml
+++ b/docker-compose-fail.yml
@@ -1,4 +1,5 @@
 crossdock:
+    dns_search: .
     build: .
     links:
         - alpha
@@ -20,6 +21,7 @@ crossdock:
       - .crossdock:/crossdock
 
 alpha:
+    dns_search: .
     image: breerly/hello-server
     ports:
         - 8080
@@ -28,6 +30,7 @@ alpha:
         - HELLO_MESSAGE=[{"status":"passed","output":"sup"}]
 
 omega:
+    dns_search: .
     image: breerly/hello-server
     ports:
         - 8080

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,5 @@
 crossdock:
+    dns_search: .
     build: .
     links:
         - alpha
@@ -20,6 +21,7 @@ crossdock:
       - .crossdock:/crossdock
 
 alpha:
+    dns_search: .
     image: breerly/hello-server
     ports:
         - 8080
@@ -28,6 +30,7 @@ alpha:
         - HELLO_MESSAGE=[{"status":"passed","output":"sup"}]
 
 omega:
+    dns_search: .
     image: breerly/hello-server
     ports:
         - 8080


### PR DESCRIPTION
- the native go DNS resolver doesn't handle `ndots:0` anyway
  (https://github.com/golang/go/issues/15419)
  - we might as well set our containers DNS configuration to absolute
    hostnames for consistency.
