### PR TITLE
Better timeout logic & messages.

### DIFF
--- a/execute/wait.go
+++ b/execute/wait.go
@@ -80,8 +80,8 @@ func waitForHTTPRequest(host string, cancel <-chan struct{}) {
 		go func() {
 			resp, err := client.Do(req)
 			if err == nil && resp.StatusCode != http.StatusOK {
-				err = errors.New(fmt.Sprintf("Expecting %v: got %v",
-					http.StatusOK, resp.Status))
+				err = fmt.Errorf("expecting %v, got %v",
+					http.StatusOK, resp.Status)
 			}
 			c <- err
 		}()

--- a/execute/wait.go
+++ b/execute/wait.go
@@ -51,7 +51,7 @@ func Wait(hosts []string, timeout time.Duration) {
 	wg.Wait()
 
 	if !timer.Stop() {
-		log.Fatalf("Error: One or more services timed out after %d second(s)", timeout)
+		log.Fatalf("Error: One or more services timed out after %v", timeout)
 	}
 	fmt.Printf("\nAll services are up after %v!\n", time.Since(begin))
 }
@@ -66,15 +66,16 @@ func waitForHTTPRequest(host string, cancel <-chan struct{}) {
 
 	err := errors.New("init")
 	for err != nil {
+		log.Printf("HTTP: HEAD %s\n", url.String())
 		req, reqErr := http.NewRequest("HEAD", url.String(), nil)
 		if reqErr != nil {
 			log.Printf("Warning: Failed to create request for URL '%s' -  skipping service '%s'",
 				url.String(), host)
 			return
 		}
+		req.Cancel = cancel
 
-		tr := &http.Transport{}
-		client := &http.Client{Transport: tr}
+		client := &http.Client{Transport: &http.Transport{}, Timeout: 500 * time.Millisecond}
 		c := make(chan error, 1)
 		go func() {
 			_, err := client.Do(req)
@@ -83,7 +84,6 @@ func waitForHTTPRequest(host string, cancel <-chan struct{}) {
 
 		select {
 		case <-cancel:
-			tr.CancelRequest(req)
 			log.Printf("HTTP: Service %v timed out. Last error: %v", host, err)
 			<-c
 			return

--- a/execute/wait.go
+++ b/execute/wait.go
@@ -78,7 +78,11 @@ func waitForHTTPRequest(host string, cancel <-chan struct{}) {
 		client := &http.Client{Transport: &http.Transport{}, Timeout: 500 * time.Millisecond}
 		c := make(chan error, 1)
 		go func() {
-			_, err := client.Do(req)
+			resp, err := client.Do(req)
+			if err == nil && resp.StatusCode != http.StatusOK {
+				err = errors.New(fmt.Sprintf("Expecting %v: got %v",
+					http.StatusOK, resp.Status))
+			}
 			c <- err
 		}()
 

--- a/execute/wait_test.go
+++ b/execute/wait_test.go
@@ -61,7 +61,7 @@ func TestObvious(t *testing.T) {
 	defer ts.Close()
 	host := ts.Listener.Addr().String()
 	cancel := make(chan struct{})
-	timer := time.AfterFunc(time.Second*2, func() {
+	timer := time.AfterFunc(2*time.Second, func() {
 		close(cancel)
 	})
 	waitForHTTPRequest(host, cancel)
@@ -72,11 +72,11 @@ func TestTooSlow(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping test in short mode.")
 	}
-	ts := httptest.NewServer(&testHandler{t: t, delay: 1 * time.Second})
+	ts := httptest.NewServer(&testHandler{t: t, delay: time.Second})
 	defer ts.Close()
 	host := ts.Listener.Addr().String()
 	cancel := make(chan struct{})
-	timer := time.AfterFunc(time.Second*2, func() {
+	timer := time.AfterFunc(2*time.Second, func() {
 		close(cancel)
 	})
 	waitForHTTPRequest(host, cancel)
@@ -91,7 +91,7 @@ func TestNotReadyThenOk(t *testing.T) {
 	defer ts.Close()
 	host := ts.Listener.Addr().String()
 	cancel := make(chan struct{})
-	timer := time.AfterFunc(time.Second*2, func() {
+	timer := time.AfterFunc(2*time.Second, func() {
 		close(cancel)
 	})
 	waitForHTTPRequest(host, cancel)

--- a/execute/wait_test.go
+++ b/execute/wait_test.go
@@ -1,0 +1,99 @@
+// Copyright (c) 2016 Uber Technologies, Inc.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in
+// all copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+// THE SOFTWARE.
+
+package execute
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+type testHandler struct {
+	t             *testing.T
+	delay         time.Duration // delay before replying
+	notReadyCount int32         // 500 that many time before returning success.
+}
+
+func (h *testHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	t := h.t
+	if h.delay != 0 {
+		t.Logf("serverHTTP: Delaying for %v", h.delay)
+		time.Sleep(h.delay)
+	}
+	if h.notReadyCount > 0 {
+		h.notReadyCount -= 1
+		t.Logf("serverHTTP: Returning %v (left: %v)",
+			http.StatusServiceUnavailable, h.notReadyCount)
+		http.Error(w, "Server not ready", http.StatusServiceUnavailable)
+		return
+	}
+	if r.Method == "HEAD" {
+		w.Header().Add("Content-Length", "0")
+		t.Logf("serverHTTP: Returning %v", http.StatusOK)
+		return
+	}
+	http.NotFound(w, r)
+}
+
+func TestObvious(t *testing.T) {
+	ts := httptest.NewServer(&testHandler{t: t, delay: 0 * time.Second})
+	defer ts.Close()
+	host := ts.Listener.Addr().String()
+	cancel := make(chan struct{})
+	timer := time.AfterFunc(time.Second*2, func() {
+		close(cancel)
+	})
+	waitForHTTPRequest(host, cancel)
+	require.True(t, timer.Stop())
+}
+
+func TestTooSlow(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	ts := httptest.NewServer(&testHandler{t: t, delay: 1 * time.Second})
+	defer ts.Close()
+	host := ts.Listener.Addr().String()
+	cancel := make(chan struct{})
+	timer := time.AfterFunc(time.Second*2, func() {
+		close(cancel)
+	})
+	waitForHTTPRequest(host, cancel)
+	require.False(t, timer.Stop())
+}
+
+func TestNotReadyThenOk(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping test in short mode.")
+	}
+	ts := httptest.NewServer(&testHandler{t: t, delay: 100 * time.Millisecond, notReadyCount: 3})
+	defer ts.Close()
+	host := ts.Listener.Addr().String()
+	cancel := make(chan struct{})
+	timer := time.AfterFunc(time.Second*2, func() {
+		close(cancel)
+	})
+	waitForHTTPRequest(host, cancel)
+	require.True(t, timer.Stop())
+}

--- a/execute/wait_test.go
+++ b/execute/wait_test.go
@@ -65,7 +65,7 @@ func TestObvious(t *testing.T) {
 		close(cancel)
 	})
 	waitForHTTPRequest(host, cancel)
-	require.True(t, timer.Stop())
+	require.True(t, timer.Stop(), "test shouldn't take more than 2 seconds")
 }
 
 func TestTooSlow(t *testing.T) {
@@ -80,7 +80,7 @@ func TestTooSlow(t *testing.T) {
 		close(cancel)
 	})
 	waitForHTTPRequest(host, cancel)
-	require.False(t, timer.Stop())
+	require.False(t, timer.Stop(), "test should timeout")
 }
 
 func TestNotReadyThenOk(t *testing.T) {
@@ -95,5 +95,5 @@ func TestNotReadyThenOk(t *testing.T) {
 		close(cancel)
 	})
 	waitForHTTPRequest(host, cancel)
-	require.True(t, timer.Stop())
+	require.True(t, timer.Stop(), "test shouldn't take more than 2 seconds")
 }

--- a/execute/wait_test.go
+++ b/execute/wait_test.go
@@ -38,19 +38,19 @@ type testHandler struct {
 func (h *testHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	t := h.t
 	if h.delay != 0 {
-		t.Logf("serverHTTP: Delaying for %v", h.delay)
+		t.Logf("testHandler: Delaying for %v", h.delay)
 		time.Sleep(h.delay)
 	}
 	if h.notReadyCount > 0 {
 		h.notReadyCount -= 1
-		t.Logf("serverHTTP: Returning %v (left: %v)",
+		t.Logf("testHandler: Returning %v (left: %v)",
 			http.StatusServiceUnavailable, h.notReadyCount)
 		http.Error(w, "Server not ready", http.StatusServiceUnavailable)
 		return
 	}
 	if r.Method == "HEAD" {
 		w.Header().Add("Content-Length", "0")
-		t.Logf("serverHTTP: Returning %v", http.StatusOK)
+		t.Logf("testHandler: Returning %v", http.StatusOK)
 		return
 	}
 	http.NotFound(w, r)

--- a/execute/wait_test.go
+++ b/execute/wait_test.go
@@ -57,7 +57,7 @@ func (h *testHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 }
 
 func TestObvious(t *testing.T) {
-	ts := httptest.NewServer(&testHandler{t: t, delay: 0 * time.Second})
+	ts := httptest.NewServer(&testHandler{t: t})
 	defer ts.Close()
 	host := ts.Listener.Addr().String()
 	cancel := make(chan struct{})

--- a/main.go
+++ b/main.go
@@ -24,6 +24,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"runtime"
 	"time"
 
 	"github.com/yarpc/crossdock/execute"
@@ -32,7 +33,7 @@ import (
 )
 
 func main() {
-	fmt.Printf("\nCrossdock starting...\n\n")
+	fmt.Printf("\nCrossdock starting (go %v)...\n\n", runtime.Version())
 
 	config, err := plan.ReadConfigFromEnviron()
 	if err != nil {

--- a/main.go
+++ b/main.go
@@ -24,7 +24,6 @@ import (
 	"fmt"
 	"log"
 	"os"
-	"runtime"
 	"time"
 
 	"github.com/yarpc/crossdock/execute"
@@ -33,7 +32,7 @@ import (
 )
 
 func main() {
-	fmt.Printf("\nCrossdock starting (go %v)...\n\n", runtime.Version())
+	fmt.Printf("\nCrossdock starting...\n\n")
 
 	config, err := plan.ReadConfigFromEnviron()
 	if err != nil {


### PR DESCRIPTION
The crossdock driver "HTTP PING" every other containers before running
the tests.

This adds a smaller sub-timeout of 500ms, making sure that we cancel and
retry the HTTP HEAD request from scratch during the global wait timeout.

Additional this fixes few log messages.
