### PR TITLE
Move to Go 1.6 only

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,7 @@ sudo: required
 language: go
 
 go:
-  - 1.5
   - 1.6
-  - 1.7
 
 services:
   - docker


### PR DESCRIPTION
Testing 1.7 wasn't actually working because of https://github.com/travis-ci/travis-ci/issues/6299 

Since Crossdock is a binary and not a library, it's probably ok to test only 1 version of Go at a time.

cc @kriskowal @abhinav @bombela 
