### PR TITLE
Allow host ready time to be configurable

### DIFF
--- a/execute/run.go
+++ b/execute/run.go
@@ -25,7 +25,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/url"
-	"time"
 
 	"github.com/crossdock/crossdock/plan"
 
@@ -97,7 +96,7 @@ func makeRequest(testCase plan.TestCase) ([]byte, error) {
 	callURL.RawQuery = args.Encode()
 
 	ctx, _ := context.WithTimeout(
-		context.Background(), testCase.Plan.Config.CallTimeout*time.Second)
+		context.Background(), testCase.Plan.Config.CallTimeout)
 	resp, err := ctxhttp.Get(ctx, nil, callURL.String())
 	if err != nil {
 		return []byte(""), err

--- a/main.go
+++ b/main.go
@@ -23,7 +23,6 @@ package main
 import (
 	"fmt"
 	"log"
-	"time"
 
 	"github.com/crossdock/crossdock/execute"
 	"github.com/crossdock/crossdock/output"
@@ -50,7 +49,7 @@ func main() {
 	}
 
 	fmt.Printf("\nWaiting on WAIT_FOR=%v\n\n", plan.Config.WaitForHosts)
-	execute.Wait(plan.Config.WaitForHosts, time.Duration(30)*time.Second)
+	execute.Wait(plan.Config.WaitForHosts, plan.Config.HostTimeout)
 
 	fmt.Printf("\nExecuting Matrix...\n\n")
 	results := execute.Run(plan)

--- a/main.go
+++ b/main.go
@@ -49,7 +49,7 @@ func main() {
 	}
 
 	fmt.Printf("\nWaiting on WAIT_FOR=%v\n\n", plan.Config.WaitForHosts)
-	execute.Wait(plan.Config.WaitForHosts, plan.Config.HostTimeout)
+	execute.Wait(plan.Config.WaitForHosts, plan.Config.WaitForTimeout)
 
 	fmt.Printf("\nExecuting Matrix...\n\n")
 	results := execute.Run(plan)

--- a/plan/config.go
+++ b/plan/config.go
@@ -30,7 +30,7 @@ import (
 
 const (
 	defaultCallTimeout = 5*time.Second
-	defaultHostTimeout = 30*time.Second
+	defaultWaitForTimeout = 30*time.Second
 )
 
 // ReadConfigFromEnviron creates a Config by looking for environment variables
@@ -38,7 +38,7 @@ func ReadConfigFromEnviron() (*Config, error) {
 	const (
 		reportKey         = "REPORT"
 		callTimeoutKey    = "CALL_TIMEOUT"
-		hostTimeoutKey    = "HOST_TIMEOUT"
+		waitForTimeoutKey = "WAIT_FOR_TIMEOUT"
 		waitKey           = "WAIT_FOR"
 		axisKeyPrefix     = "AXIS_"
 		behaviorKeyPrefix = "BEHAVIOR_"
@@ -49,9 +49,9 @@ func ReadConfigFromEnviron() (*Config, error) {
 	if callTimeout == 0 {
 		callTimeout = defaultCallTimeout
 	}
-	hostTimeout, _ := time.ParseDuration(os.Getenv(hostTimeoutKey))
-	if hostTimeout == 0 {
-		hostTimeout = defaultHostTimeout
+	waitForTimeout, _ := time.ParseDuration(os.Getenv(waitForTimeoutKey))
+	if waitForTimeout == 0 {
+		waitForTimeout = defaultWaitForTimeout
 	}
 
 	waitForHosts := trimCollection(strings.Split(os.Getenv(waitKey), ","))
@@ -76,7 +76,7 @@ func ReadConfigFromEnviron() (*Config, error) {
 	config := &Config{
 		Reports:        reports,
 		CallTimeout:    callTimeout,
-		HostTimeout:    hostTimeout,
+		WaitForTimeout: waitForTimeout,
 		WaitForHosts:   waitForHosts,
 		Axes:           axes,
 		Behaviors:      behaviors,

--- a/plan/config.go
+++ b/plan/config.go
@@ -30,8 +30,8 @@ import (
 )
 
 const (
-	defaultCallTimeout = 5
-	defaultHostTimeout = 30
+	defaultCallTimeoutInSeconds = 5
+	defaultHostTimeoutInSeconds = 30
 )
 
 // ReadConfigFromEnviron creates a Config by looking for environment variables
@@ -48,11 +48,11 @@ func ReadConfigFromEnviron() (*Config, error) {
 
 	callTimeout, _ := strconv.Atoi(os.Getenv(callTimeoutKey))
 	if callTimeout == 0 {
-		callTimeout = defaultCallTimeout
+		callTimeout = defaultCallTimeoutInSeconds
 	}
 	hostTimeout, _ := strconv.Atoi(os.Getenv(hostTimeoutKey))
 	if hostTimeout == 0 {
-		hostTimeout = defaultHostTimeout
+		hostTimeout = defaultHostTimeoutInSeconds
 	}
 
 	waitForHosts := trimCollection(strings.Split(os.Getenv(waitKey), ","))

--- a/plan/config.go
+++ b/plan/config.go
@@ -24,14 +24,13 @@ import (
 	"errors"
 	"os"
 	"sort"
-	"strconv"
 	"strings"
 	"time"
 )
 
 const (
-	defaultCallTimeoutInSeconds = 5
-	defaultHostTimeoutInSeconds = 30
+	defaultCallTimeout = 5*time.Second
+	defaultHostTimeout = 30*time.Second
 )
 
 // ReadConfigFromEnviron creates a Config by looking for environment variables
@@ -46,13 +45,13 @@ func ReadConfigFromEnviron() (*Config, error) {
 		jsonReportPathKey = "JSON_REPORT_PATH"
 	)
 
-	callTimeout, _ := strconv.Atoi(os.Getenv(callTimeoutKey))
+	callTimeout, _ := time.ParseDuration(os.Getenv(callTimeoutKey))
 	if callTimeout == 0 {
-		callTimeout = defaultCallTimeoutInSeconds
+		callTimeout = defaultCallTimeout
 	}
-	hostTimeout, _ := strconv.Atoi(os.Getenv(hostTimeoutKey))
+	hostTimeout, _ := time.ParseDuration(os.Getenv(hostTimeoutKey))
 	if hostTimeout == 0 {
-		hostTimeout = defaultHostTimeoutInSeconds
+		hostTimeout = defaultHostTimeout
 	}
 
 	waitForHosts := trimCollection(strings.Split(os.Getenv(waitKey), ","))
@@ -76,8 +75,8 @@ func ReadConfigFromEnviron() (*Config, error) {
 
 	config := &Config{
 		Reports:        reports,
-		CallTimeout:    callTimeout*time.Second,
-		HostTimeout:    hostTimeout*time.Second,
+		CallTimeout:    callTimeout,
+		HostTimeout:    hostTimeout,
 		WaitForHosts:   waitForHosts,
 		Axes:           axes,
 		Behaviors:      behaviors,

--- a/plan/config.go
+++ b/plan/config.go
@@ -29,13 +29,17 @@ import (
 	"time"
 )
 
-const defaultCallTimeout = 5
+const (
+	defaultCallTimeout = 5
+	defaultHostTimeout = 30
+)
 
 // ReadConfigFromEnviron creates a Config by looking for environment variables
 func ReadConfigFromEnviron() (*Config, error) {
 	const (
 		reportKey         = "REPORT"
 		callTimeoutKey    = "CALL_TIMEOUT"
+		hostTimeoutKey    = "HOST_TIMEOUT"
 		waitKey           = "WAIT_FOR"
 		axisKeyPrefix     = "AXIS_"
 		behaviorKeyPrefix = "BEHAVIOR_"
@@ -45,6 +49,10 @@ func ReadConfigFromEnviron() (*Config, error) {
 	callTimeout, _ := strconv.Atoi(os.Getenv(callTimeoutKey))
 	if callTimeout == 0 {
 		callTimeout = defaultCallTimeout
+	}
+	hostTimeout, _ := strconv.Atoi(os.Getenv(hostTimeoutKey))
+	if hostTimeout == 0 {
+		hostTimeout = defaultHostTimeout
 	}
 
 	waitForHosts := trimCollection(strings.Split(os.Getenv(waitKey), ","))
@@ -68,7 +76,8 @@ func ReadConfigFromEnviron() (*Config, error) {
 
 	config := &Config{
 		Reports:        reports,
-		CallTimeout:    time.Duration(callTimeout),
+		CallTimeout:    callTimeout*time.Second,
+		HostTimeout:    hostTimeout*time.Second,
 		WaitForHosts:   waitForHosts,
 		Axes:           axes,
 		Behaviors:      behaviors,

--- a/plan/config_test.go
+++ b/plan/config_test.go
@@ -35,7 +35,7 @@ func TestReadConfigFromEnviron(t *testing.T) {
 	os.Setenv("AXIS_TRANSPORT", "http,tchannel")
 	os.Setenv("BEHAVIOR_ECHO", "client,server,transport")
 	os.Setenv("CALL_TIMEOUT", "10s")
-	os.Setenv("HOST_TIMEOUT", "20s")
+	os.Setenv("WAIT_FOR_TIMEOUT", "20s")
 	defer os.Clearenv()
 
 	config, err := ReadConfigFromEnviron()
@@ -68,7 +68,7 @@ func TestReadConfigFromEnviron(t *testing.T) {
 
 	assert.Equal(t, 10*time.Second, config.CallTimeout)
 
-	assert.Equal(t, 20*time.Second, config.HostTimeout)
+	assert.Equal(t, 20*time.Second, config.WaitForTimeout)
 }
 
 func TestReadConfigFromEnvironTrimsWhitespace(t *testing.T) {

--- a/plan/config_test.go
+++ b/plan/config_test.go
@@ -34,8 +34,8 @@ func TestReadConfigFromEnviron(t *testing.T) {
 	os.Setenv("AXIS_SERVER", "yarpc-go,yarpc-node")
 	os.Setenv("AXIS_TRANSPORT", "http,tchannel")
 	os.Setenv("BEHAVIOR_ECHO", "client,server,transport")
-	os.Setenv("CALL_TIMEOUT", "10")
-	os.Setenv("HOST_TIMEOUT", "20")
+	os.Setenv("CALL_TIMEOUT", "10s")
+	os.Setenv("HOST_TIMEOUT", "20s")
 	defer os.Clearenv()
 
 	config, err := ReadConfigFromEnviron()

--- a/plan/config_test.go
+++ b/plan/config_test.go
@@ -23,6 +23,7 @@ package plan
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -33,6 +34,8 @@ func TestReadConfigFromEnviron(t *testing.T) {
 	os.Setenv("AXIS_SERVER", "yarpc-go,yarpc-node")
 	os.Setenv("AXIS_TRANSPORT", "http,tchannel")
 	os.Setenv("BEHAVIOR_ECHO", "client,server,transport")
+	os.Setenv("CALL_TIMEOUT", "10")
+	os.Setenv("HOST_TIMEOUT", "20")
 	defer os.Clearenv()
 
 	config, err := ReadConfigFromEnviron()
@@ -62,6 +65,10 @@ func TestReadConfigFromEnviron(t *testing.T) {
 			ClientAxis: "client",
 			ParamsAxes: []string{"server", "transport"},
 		}})
+
+	assert.Equal(t, 10*time.Second, config.CallTimeout)
+
+	assert.Equal(t, 20*time.Second, config.HostTimeout)
 }
 
 func TestReadConfigFromEnvironTrimsWhitespace(t *testing.T) {

--- a/plan/entities.go
+++ b/plan/entities.go
@@ -26,6 +26,7 @@ import "time"
 type Config struct {
 	Reports        []string
 	CallTimeout    time.Duration
+	HostTimeout    time.Duration
 	WaitForHosts   []string
 	Axes           Axes
 	Behaviors      Behaviors

--- a/plan/entities.go
+++ b/plan/entities.go
@@ -26,7 +26,7 @@ import "time"
 type Config struct {
 	Reports        []string
 	CallTimeout    time.Duration
-	HostTimeout    time.Duration
+	WaitForTimeout time.Duration
 	WaitForHosts   []string
 	Axes           Axes
 	Behaviors      Behaviors


### PR DESCRIPTION
I'm running into an issue where the hosts are not ready in the default 30 seconds wait time. I'm adding this to allow users to configure the host ready check time.