### PR TITLE
plan: Fix wrong client axis due to sorting

### DIFF
--- a/plan/config.go
+++ b/plan/config.go
@@ -29,8 +29,8 @@ import (
 )
 
 const (
-	defaultCallTimeout = 5*time.Second
-	defaultWaitForTimeout = 30*time.Second
+	defaultCallTimeout    = 5 * time.Second
+	defaultWaitForTimeout = 30 * time.Second
 )
 
 // ReadConfigFromEnviron creates a Config by looking for environment variables
@@ -92,14 +92,17 @@ func ReadConfigFromEnviron() (*Config, error) {
 func parseBehavior(d string) Behavior {
 	pair := strings.SplitN(d, "=", 2)
 	key := strings.ToLower(pair[0])
+
 	values := strings.Split(pair[1], ",")
 	values = trimCollection(values)
+	clientAxis := values[0]
+	values = values[1:]
 	sort.Strings(values)
 
 	behavior := Behavior{
 		Name:       key,
-		ClientAxis: values[0],
-		ParamsAxes: values[1:],
+		ClientAxis: clientAxis,
+		ParamsAxes: values,
 	}
 
 	return behavior

--- a/plan/config_test.go
+++ b/plan/config_test.go
@@ -80,3 +80,39 @@ func TestReadConfigFromEnvironTrimsWhitespace(t *testing.T) {
 
 	assert.Equal(t, config.WaitForHosts, []string{"alpha", "omega"})
 }
+
+func TestParseBehavior(t *testing.T) {
+	tests := []struct {
+		give string
+		want Behavior
+	}{
+		{
+			give: "foo=client,server",
+			want: Behavior{
+				Name:       "foo",
+				ClientAxis: "client",
+				ParamsAxes: []string{"server"},
+			},
+		},
+		{
+			give: "x=a,b,c,d",
+			want: Behavior{
+				Name:       "x",
+				ClientAxis: "a",
+				ParamsAxes: []string{"b", "c", "d"},
+			},
+		},
+		{
+			give: "y=c,b,a",
+			want: Behavior{
+				Name:       "y",
+				ClientAxis: "c",
+				ParamsAxes: []string{"a", "b"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, parseBehavior(tt.give))
+	}
+}


### PR DESCRIPTION
This fixes a bug where the wrong axis was selected as the client axis
because the list of axes was sorted BEFORE selecting `params[0]` as the
client axis.

CC @breerly @bombela @kriskowal