### PR TITLE
Start of horizontal scaling

### DIFF
--- a/main.go
+++ b/main.go
@@ -44,10 +44,12 @@ func main() {
 
 	plan := plan.New(config)
 
+	// TODO: There might be side effects on the reporter for not all TestCases being present
 	if err := reporter.Start(plan); err != nil {
 		log.Fatal(err)
 	}
 
+	// TODO: WaitForHosts might be different depending on horizontal scaling
 	fmt.Printf("\nWaiting on WAIT_FOR=%v\n\n", plan.Config.WaitForHosts)
 	execute.Wait(plan.Config.WaitForHosts, plan.Config.WaitForTimeout)
 

--- a/plan/entities.go
+++ b/plan/entities.go
@@ -24,13 +24,15 @@ import "time"
 
 // Config describes the unstructured test plan
 type Config struct {
-	Reports        []string
-	CallTimeout    time.Duration
-	WaitForTimeout time.Duration
-	WaitForHosts   []string
-	Axes           Axes
-	Behaviors      Behaviors
-	JSONReportPath string
+	Reports              []string
+	CallTimeout          time.Duration
+	WaitForTimeout       time.Duration
+	WaitForHosts         []string
+	Axes                 Axes
+	Behaviors            Behaviors
+	JSONReportPath       string
+	HorizontalScaleShard  int
+	HorizontalScaleCount int
 }
 
 // Axes is a collection of Axis objects sortable by axis name.

--- a/plan/new_test.go
+++ b/plan/new_test.go
@@ -180,3 +180,89 @@ func TestNew(t *testing.T) {
 
 	assert.Equal(t, plan.TestCases, wanted)
 }
+
+func TestGetHorizontalScaleIndices(t *testing.T) {
+	tests := []struct {
+		horizontalScaleCount int
+		count                int
+		results              [][]int
+	}{
+		{
+			horizontalScaleCount: 3,
+			count:                1,
+			results: [][]int{
+				[]int{0},
+				nil,
+				nil,
+			},
+		},
+		{
+			horizontalScaleCount: 3,
+			count:                2,
+			results: [][]int{
+				[]int{0},
+				[]int{1},
+				nil,
+			},
+		},
+		{
+			horizontalScaleCount: 3,
+			count:                3,
+			results: [][]int{
+				[]int{0},
+				[]int{1},
+				[]int{2},
+			},
+		},
+		{
+			horizontalScaleCount: 3,
+			count:                4,
+			results: [][]int{
+				[]int{0, 3},
+				[]int{1},
+				[]int{2},
+			},
+		},
+		{
+			horizontalScaleCount: 3,
+			count:                5,
+			results: [][]int{
+				[]int{0, 3},
+				[]int{1, 4},
+				[]int{2},
+			},
+		},
+		{
+			horizontalScaleCount: 3,
+			count:                6,
+			results: [][]int{
+				[]int{0, 3},
+				[]int{1, 4},
+				[]int{2, 5},
+			},
+		},
+		{
+			horizontalScaleCount: 3,
+			count:                7,
+			results: [][]int{
+				[]int{0, 3, 6},
+				[]int{1, 4},
+				[]int{2, 5},
+			},
+		},
+		{
+			horizontalScaleCount: 3,
+			count:                8,
+			results: [][]int{
+				[]int{0, 3, 6},
+				[]int{1, 4, 7},
+				[]int{2, 5},
+			},
+		},
+	}
+	for _, tt := range tests {
+		for i := 0; i < tt.horizontalScaleCount; i++ {
+			assert.Equal(t, tt.results[i], getHorizontalScaleIndices(i+1, tt.horizontalScaleCount, tt.count))
+		}
+	}
+}


### PR DESCRIPTION
This is in no way complete or anything, this is just to show the basic concept I have in my head.

The idea would be for example you could have three instances of crossdock with the same config, and for each one you would have set:

```
#1
HORIZONTAL_SCALE_SHARD=1
HORIZONTAL_SCALE_COUNT=3

#2
HORIZONTAL_SCALE_SHARD=2
HORIZONTAL_SCALE_COUNT=3

#3
HORIZONTAL_SCALE_SHARD=3
HORIZONTAL_SCALE_COUNT=3
```

There's some issues I think might happen:

- I think `[]TestCase` should be all that `Plan` has on it, ie `TestCase` encapsulates all data from `Config` that is needed. This should prevent problems in other areas if not all `TestCases` are present from the Config.
- See comment on `WaitForHost`
- See comment on `Reporters`
- Not all error checking is done (check that shard <= count, check that shard >=0, count >= 0, etc)